### PR TITLE
Enable Vim surround across editors

### DIFF
--- a/dot_config/Code/User/settings.json
+++ b/dot_config/Code/User/settings.json
@@ -15,6 +15,7 @@
   // Vim extension settings
   "vim.useSystemClipboard": true,
   "vim.useCtrlKeys": true,
+  "vim.surround": true,
   "vim.leader": "<space>",
   "vim.handleKeys": {
     "<tab>": false,

--- a/dot_config/nvim/init.lua
+++ b/dot_config/nvim/init.lua
@@ -27,4 +27,5 @@ require("lazy").setup({
       vim.cmd("colorscheme kanagawa")
     end,
   },
+  { "tpope/vim-surround" },
 })

--- a/dot_vsvimrc
+++ b/dot_vsvimrc
@@ -14,6 +14,9 @@ set scrolloff=8
 set guicursor+=a:blinkon0
 colorscheme kanagawa
 
+" Enable surround mappings if the plugin is available
+silent! runtime macros/surround.vim
+
 " Search
 set ignorecase
 set smartcase


### PR DESCRIPTION
## Summary
- Enable surround motions in VS Code's Vim extension
- Add vim-surround plugin to Neovim config
- Load surround macros in VsVim configuration

## Testing
- `nvim --headless +q`


------
https://chatgpt.com/codex/tasks/task_e_688f3c1386c08324b8420665c23d5d87