### PR TITLE
Install and use Kanagawa theme in VS Code

### DIFF
--- a/.chezmoitemplates/vscode-settings.json
+++ b/.chezmoitemplates/vscode-settings.json
@@ -7,6 +7,7 @@
   "editor.lineNumbers": "relative",
   "editor.renderLineHighlight": "none",
   "workbench.colorTheme": "Kanagawa",
+  "workbench.preferredDarkColorTheme": "Kanagawa",
   "workbench.colorCustomizations": {
     "editorCursor.foreground": "#FF5000",
     "editorCursor.background": "#000000"

--- a/vscode_extensions.txt
+++ b/vscode_extensions.txt
@@ -1,2 +1,2 @@
 vscodevim.vim
-quillbard.kanagawa
+qufiwefefwoyn.kanagawa


### PR DESCRIPTION
## Summary
- ensure Kanagawa theme extension is installed automatically
- set Kanagawa as the preferred VS Code theme

## Testing
- `command -v code >/dev/null && echo found || echo 'code command not found'`


------
https://chatgpt.com/codex/tasks/task_e_68903f3107d48324a2b8947736bf8873