### PR TITLE
feat: decrease VS Code editor font size

### DIFF
--- a/.chezmoitemplates/vscode-settings.json
+++ b/.chezmoitemplates/vscode-settings.json
@@ -4,6 +4,7 @@
   "editor.cursorSurroundingLinesStyle": "all",
   "editor.cursorBlinking": "solid",
   "editor.cursorSmoothCaretAnimation": "off",
+  "editor.fontSize": 14,
   "editor.lineNumbers": "relative",
   "editor.renderLineHighlight": "none",
   "workbench.colorTheme": "Kanagawa",


### PR DESCRIPTION
## Summary
- reduce VS Code editor font size for smaller text

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890440162b483249e8d30ee522d63be