### PR TITLE
Add leader-based tab switching in Neovim and VS Code

### DIFF
--- a/.chezmoitemplates/vscode-settings.json
+++ b/.chezmoitemplates/vscode-settings.json
@@ -31,7 +31,16 @@
       "before": ["<Esc>"],
       "after": ["<Esc>"],
       "commands": [":nohl"]
-    }
+    },
+    { "before": ["<leader>", "1"], "commands": ["workbench.action.openEditorAtIndex1"] },
+    { "before": ["<leader>", "2"], "commands": ["workbench.action.openEditorAtIndex2"] },
+    { "before": ["<leader>", "3"], "commands": ["workbench.action.openEditorAtIndex3"] },
+    { "before": ["<leader>", "4"], "commands": ["workbench.action.openEditorAtIndex4"] },
+    { "before": ["<leader>", "5"], "commands": ["workbench.action.openEditorAtIndex5"] },
+    { "before": ["<leader>", "6"], "commands": ["workbench.action.openEditorAtIndex6"] },
+    { "before": ["<leader>", "7"], "commands": ["workbench.action.openEditorAtIndex7"] },
+    { "before": ["<leader>", "8"], "commands": ["workbench.action.openEditorAtIndex8"] },
+    { "before": ["<leader>", "9"], "commands": ["workbench.action.openEditorAtIndex9"] }
   ],
   "vim.insertModeKeyBindings": [
     { "before": ["<Esc>"], "after": ["<Esc>", "<C-g>u"] }

--- a/dot_config/nvim/init.lua
+++ b/dot_config/nvim/init.lua
@@ -29,3 +29,19 @@ require("lazy").setup({
   },
   { "tpope/vim-surround" },
 })
+
+-- Map <leader>1..9 to switch tabs
+if vim.g.vscode then
+  for i = 1, 9 do
+    vim.keymap.set("n", "<leader>" .. i, function()
+      vim.fn.VSCodeNotify("workbench.action.openEditorAtIndex" .. i)
+    end, { desc = "Go to tab " .. i, silent = true })
+  end
+else
+  for i = 1, 9 do
+    vim.keymap.set("n", "<leader>" .. i, i .. "gt", {
+      desc = "Go to tab " .. i,
+      silent = true,
+    })
+  end
+end


### PR DESCRIPTION
## Summary
- Map <leader>1..9 to jump to corresponding tab in Neovim
- Make the same leader mappings work in VS Code via VS Code Vim settings

## Testing
- `nvim --headless -u dot_config/nvim/init.lua +q`
- `python - <<'PY'
import json, re, pathlib
text = pathlib.Path('.chezmoitemplates/vscode-settings.json').read_text()
text = re.sub(r'//.*', '', text)
json.loads(text)
print('JSON parsed')
PY`


------
https://chatgpt.com/codex/tasks/task_e_689045a437d08324a6a5bbfcf486319b