### PR TITLE
Use bar cursor in insert mode

### DIFF
--- a/.chezmoitemplates/vscode-settings.json
+++ b/.chezmoitemplates/vscode-settings.json
@@ -4,6 +4,7 @@
   "editor.cursorSurroundingLinesStyle": "all",
   "editor.cursorBlinking": "solid",
   "editor.cursorSmoothCaretAnimation": "off",
+  "editor.cursorStyle": "line",
   "editor.fontSize": 14,
   "editor.lineNumbers": "relative",
   "editor.renderLineHighlight": "none",
@@ -24,6 +25,14 @@
     "<S-tab>": false,
     "<C-o>": true,
     "<C-i>": true
+  },
+  "vim.cursorStylePerMode": {
+    "normal": "block",
+    "insert": "line",
+    "replace": "underline",
+    "visual": "block",
+    "visualLine": "block",
+    "visualBlock": "block"
   },
   "vim.normalModeKeyBindingsNonRecursive": [
     { "before": ["<leader>", "v"], "after": ["<C-v>"] },

--- a/dot_config/nvim/init.lua
+++ b/dot_config/nvim/init.lua
@@ -1,9 +1,10 @@
 -- Minimal Neovim config with Kanagawa theme
--- Relative line numbers and a non‑blinking orange cursor
+-- Relative line numbers, a non‑blinking orange cursor and a vertical bar in insert mode
 
 vim.opt.number = true
 vim.opt.relativenumber = true
 vim.opt.termguicolors = true
+vim.opt.guicursor = "n-v-c-sm:block,i-ci-ve:ver25,r-cr-o:hor20"
 vim.opt.guicursor:append("a:blinkon0")
 vim.api.nvim_set_hl(0, "Cursor", { fg = "#FF5000", bg = "#000000" })
 

--- a/dot_vsvimrc
+++ b/dot_vsvimrc
@@ -10,9 +10,10 @@ set relativenumber
 set cursorline
 set scrolloff=8
 
-" Disable blinking cursor and use Kanagawa theme if available
+" Disable blinking cursor, use a vertical bar in insert mode and use Kanagawa theme if available
+set guicursor=n-v-c:block,i-ci:ver25,r-cr:hor20,o:hor50
 set guicursor+=a:blinkon0
-colorscheme kanagawa
+silent! colorscheme kanagawa
 
 " Enable surround mappings if the plugin is available
 silent! runtime macros/surround.vim


### PR DESCRIPTION
## Summary
- show a vertical bar cursor while in insert mode for Neovim, VsVim, and VSCode
- skip VsVim colorscheme if Kanagawa theme is missing

## Testing
- `nvim --version`
- `nvim --headless -u NONE +'luafile dot_config/nvim/init.lua' +q`
- `nvim --headless -u NONE +'source dot_vsvimrc' +q`
- `python - <<'PY'\nimport json5\nwith open('.chezmoitemplates/vscode-settings.json') as f:\n    json5.load(f)\nPY`


------
https://chatgpt.com/codex/tasks/task_e_689046651a9c83248cdbbf7061894bb2