### PR TITLE
Add Helix editor with Kanagawa theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Dotfiles
 
-Personal dotfiles for my development environment, managed with [chezmoi](https://www.chezmoi.io/). Configurations for tools like Neovim, VS Code, and more are kept under version control so they can be reproduced on any machine.
+Personal dotfiles for my development environment, managed with [chezmoi](https://www.chezmoi.io/). Configurations for tools like Neovim, Helix, VS Code, and more are kept under version control so they can be reproduced on any machine.
 
 ## Installation with chezmoi
 

--- a/dot_config/helix/config.toml
+++ b/dot_config/helix/config.toml
@@ -1,0 +1,1 @@
+theme = "kanagawa"

--- a/dot_config/nvim/init.lua
+++ b/dot_config/nvim/init.lua
@@ -1,5 +1,6 @@
 -- Minimal Neovim config with Kanagawa theme
 -- Relative line numbers and a non‑blinking orange cursor
+-- Only apply the colorscheme when not running inside VS Code
 
 vim.opt.number = true
 vim.opt.relativenumber = true
@@ -23,6 +24,9 @@ vim.opt.rtp:prepend(lazypath)
 require("lazy").setup({
   {
     "rebelot/kanagawa.nvim",
+    cond = function()
+      return not vim.g.vscode
+    end,
     config = function()
       vim.cmd("colorscheme kanagawa")
     end,

--- a/run_once_30-install-helix.ps1.tmpl
+++ b/run_once_30-install-helix.ps1.tmpl
@@ -1,0 +1,12 @@
+{{ if eq .chezmoi.os "windows" -}}
+if (Get-Command hx -ErrorAction SilentlyContinue) {
+    exit 0
+}
+if (Get-Command winget -ErrorAction SilentlyContinue) {
+    winget install --id Helix.Helix -e
+} elseif (Get-Command choco -ErrorAction SilentlyContinue) {
+    choco install helix -y
+} else {
+    Write-Output "No supported package manager found for Helix installation."
+}
+{{ end -}}

--- a/run_once_30-install-helix.sh.tmpl
+++ b/run_once_30-install-helix.sh.tmpl
@@ -1,0 +1,19 @@
+{{ if ne .chezmoi.os "windows" -}}
+#!/usr/bin/env bash
+set -e
+if command -v hx >/dev/null 2>&1; then
+    exit 0
+fi
+if command -v brew >/dev/null 2>&1; then
+    brew install helix
+elif command -v apt-get >/dev/null 2>&1; then
+    sudo apt-get update
+    sudo apt-get install -y helix
+elif command -v pacman >/dev/null 2>&1; then
+    sudo pacman --noconfirm -S helix
+elif command -v dnf >/dev/null 2>&1; then
+    sudo dnf install -y helix
+else
+    echo "No supported package manager found for Helix installation."
+fi
+{{ end -}}


### PR DESCRIPTION
## Summary
- install Helix via chezmoi run-once scripts for Unix and Windows
- configure Helix to use the Kanagawa theme
- load the Kanagawa theme in Neovim only for terminal sessions

## Testing
- `bash -n run_once_30-install-helix.sh.tmpl`
- `nvim --version` *(fails: command not found)*
- `pwsh -v` *(fails: command not found)*
- `powershell -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68904939f5ac83248ede83134a1f2ff4