### PR TITLE
Switch Neovim to light Kanagawa theme

### DIFF
--- a/dot_config/nvim/init.lua
+++ b/dot_config/nvim/init.lua
@@ -4,6 +4,7 @@
 vim.opt.number = true
 vim.opt.relativenumber = true
 vim.opt.termguicolors = true
+vim.opt.background = "light"
 vim.opt.guicursor = "n-v-c-sm:block,i-ci-ve:ver25,r-cr-o:hor20"
 vim.opt.guicursor:append("a:blinkon0")
 vim.api.nvim_set_hl(0, "Cursor", { fg = "#FF5000", bg = "#000000" })
@@ -28,7 +29,7 @@ require("lazy").setup({
       return not vim.g.vscode
     end,
     config = function()
-      vim.cmd("colorscheme kanagawa")
+      vim.cmd("colorscheme kanagawa-lotus")
     end,
   },
   { "tpope/vim-surround" },


### PR DESCRIPTION
## Summary
- use Neovim's light background
- switch Kanagawa to its light variant

## Testing
- `nvim --headless -u dot_config/nvim/init.lua +q`


------
https://chatgpt.com/codex/tasks/task_e_68904c6d51788324bf323688d715789a