### PR TITLE
feat: add jump-view navigation bindings

### DIFF
--- a/.chezmoitemplates/vscode-keybindings.json
+++ b/.chezmoitemplates/vscode-keybindings.json
@@ -411,5 +411,21 @@
     "key": "alt+o",
     "command": "clangd.switchheadersource",
     "when": "editorTextFocus && resourceLangId == 'c' || editorTextFocus && resourceLangId == 'cpp' || editorTextFocus && resourceLangId == 'cuda-cpp' || editorTextFocus && resourceLangId == 'objective-c' || editorTextFocus && resourceLangId == 'objective-cpp'"
+  },
+  {
+    "key": "ctrl+h",
+    "command": "jump_view_left"
+  },
+  {
+    "key": "ctrl+j",
+    "command": "jump_view_down"
+  },
+  {
+    "key": "ctrl+k",
+    "command": "jump_view_up"
+  },
+  {
+    "key": "ctrl+l",
+    "command": "jump_view_right"
   }
 ]

--- a/vscode_extensions.txt
+++ b/vscode_extensions.txt
@@ -1,2 +1,3 @@
 vscodevim.vim
 qufiwefefwoyn.kanagawa
+chillee.jump-view


### PR DESCRIPTION
## Summary
- add jump-view extension to VS Code extension list
- map Ctrl+h/j/k/l to jump between splits and sidebars

## Testing
- `python - <<'PY'
import re, json, pathlib
text = pathlib.Path('.chezmoitemplates/vscode-keybindings.json').read_text()
text = re.sub(r'//.*', '', text)
json.loads(text)
print('JSON OK')
PY`

------
https://chatgpt.com/codex/tasks/task_e_6890b44c85ac8324809c4723a37b2d68