### PR TITLE
feat: add VS Code fuzzy finder keybindings

### DIFF
--- a/.chezmoitemplates/vscode-keybindings.json
+++ b/.chezmoitemplates/vscode-keybindings.json
@@ -82,6 +82,18 @@
     "key": "shift+f3",
     "command": "workbench.action.quickOpen"
   },
+  // Fuzzy search open editors
+  {
+    "key": "space b",
+    "command": "workbench.action.showAllEditorsByMostRecentlyUsed",
+    "when": "editorTextFocus"
+  },
+  // Fuzzy search workspace files
+  {
+    "key": "space k",
+    "command": "workbench.action.quickOpen",
+    "when": "editorTextFocus"
+  },
   // Scroll up 16 Lines
   // Matches Nvim where small scrolls will keep the cursor in exacty the same relative place on the screen
   {

--- a/.chezmoitemplates/vscode-settings.json
+++ b/.chezmoitemplates/vscode-settings.json
@@ -49,7 +49,9 @@
     { "before": ["<leader>", "6"], "commands": ["workbench.action.openEditorAtIndex6"] },
     { "before": ["<leader>", "7"], "commands": ["workbench.action.openEditorAtIndex7"] },
     { "before": ["<leader>", "8"], "commands": ["workbench.action.openEditorAtIndex8"] },
-    { "before": ["<leader>", "9"], "commands": ["workbench.action.openEditorAtIndex9"] }
+    { "before": ["<leader>", "9"], "commands": ["workbench.action.openEditorAtIndex9"] },
+    { "before": ["<leader>", "b"], "commands": ["workbench.action.showAllEditorsByMostRecentlyUsed"] },
+    { "before": ["<leader>", "k"], "commands": ["workbench.action.quickOpen"] }
   ],
   "vim.insertModeKeyBindings": [
     { "before": ["<Esc>"], "after": ["<Esc>", "<C-g>u"] }


### PR DESCRIPTION
## Summary
- add leader mappings to fuzzy search open editors or files in VS Code
- expose equivalent Space+b/Space+k keybindings for quick fuzzy lookup

## Testing
- `python - <<'PY'
import re, json, sys, pathlib
for path in ['.chezmoitemplates/vscode-settings.json', '.chezmoitemplates/vscode-keybindings.json']:
    text=pathlib.Path(path).read_text()
    text=re.sub(r'//.*', '', text)
    try:
        json.loads(text)
        print(f'{path}: OK')
    except Exception as e:
        print(f'{path}: FAIL {e}')
PY`


------
https://chatgpt.com/codex/tasks/task_e_6890b19ba5848324ba94fefa2c3191b5