### PR TITLE
Remove deprecated jump-view extension

### DIFF
--- a/.chezmoitemplates/vscode-keybindings.json
+++ b/.chezmoitemplates/vscode-keybindings.json
@@ -426,18 +426,18 @@
   },
   {
     "key": "ctrl+h",
-    "command": "jump_view_left"
+    "command": "workbench.action.focusLeftGroup"
   },
   {
     "key": "ctrl+j",
-    "command": "jump_view_down"
+    "command": "workbench.action.focusBelowGroup"
   },
   {
     "key": "ctrl+k",
-    "command": "jump_view_up"
+    "command": "workbench.action.focusAboveGroup"
   },
   {
     "key": "ctrl+l",
-    "command": "jump_view_right"
+    "command": "workbench.action.focusRightGroup"
   }
 ]

--- a/vscode_extensions.txt
+++ b/vscode_extensions.txt
@@ -1,3 +1,2 @@
 vscodevim.vim
 qufiwefefwoyn.kanagawa
-chillee.jump-view


### PR DESCRIPTION
## Summary
- replace `jump_view_*` keybindings with built-in `focus*Group` commands
- drop unavailable `chillee.jump-view` extension from VS Code extension list

## Testing
- `python - <<'PY'
import re, json, pathlib, sys
text = pathlib.Path('.chezmoitemplates/vscode-keybindings.json').read_text()
text_no_comments = re.sub(r'//.*', '', text)
json.loads(text_no_comments)
print('keybindings JSON parses')
PY`


------
https://chatgpt.com/codex/tasks/task_e_689170e5b1ac832484fe84c400e2c964