### PR TITLE
Simplify Neovim config with Kanagawa theme and mini.surround

### DIFF
--- a/dot_config/nvim/init.lua
+++ b/dot_config/nvim/init.lua
@@ -1,46 +1,6 @@
--- Minimal Neovim config with Kanagawa theme
+vim.opt.rtp:prepend("~/.local/share/nvim/site/pack/lazy/start/lazy.nvim")
 
--- Enable true color support for better colors
-vim.opt.termguicolors = true
+require("plugins")
 
-local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
-if not vim.loop.fs_stat(lazypath) then
-  vim.fn.system({
-    "git",
-    "clone",
-    "--filter=blob:none",
-    "https://github.com/folke/lazy.nvim.git",
-    "--branch=stable",
-    lazypath,
-  })
-end
-vim.opt.rtp:prepend(lazypath)
-
-require("lazy").setup({
-  {
-    "rebelot/kanagawa.nvim",
-    cond = function()
-      return not vim.g.vscode
-    end,
-    config = function()
-      vim.cmd("colorscheme kanagawa")
-    end,
-  },
-  { "tpope/vim-surround" },
-})
-
--- Map <leader>1..9 to switch tabs
-if vim.g.vscode then
-  for i = 1, 9 do
-    vim.keymap.set("n", "<leader>" .. i, function()
-      vim.fn.VSCodeNotify("workbench.action.openEditorAtIndex" .. i)
-    end, { desc = "Go to tab " .. i, silent = true })
-  end
-else
-  for i = 1, 9 do
-    vim.keymap.set("n", "<leader>" .. i, i .. "gt", {
-      desc = "Go to tab " .. i,
-      silent = true,
-    })
-  end
-end
+-- Set colorscheme
+vim.cmd.colorscheme("kanagawa")

--- a/dot_config/nvim/lua/plugins.lua
+++ b/dot_config/nvim/lua/plugins.lua
@@ -1,0 +1,14 @@
+require("lazy").setup({
+  {
+    "rebelot/kanagawa.nvim",
+    lazy = false,
+    priority = 1000,
+  },
+  {
+    "echasnovski/mini.surround",
+    version = "*",
+    config = function()
+      require("mini.surround").setup()
+    end,
+  },
+})


### PR DESCRIPTION
## Summary
- replace existing Neovim configuration with a minimal lazy.nvim setup
- install Kanagawa colorscheme and mini.surround

## Testing
- `nvim --version | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68917aef49e4832480ac7567bce7cd81