### PR TITLE
Ensure space key works in VS Code insert mode

### DIFF
--- a/.chezmoitemplates/vscode-keybindings.json
+++ b/.chezmoitemplates/vscode-keybindings.json
@@ -86,13 +86,13 @@
   {
     "key": "space b",
     "command": "workbench.action.showAllEditorsByMostRecentlyUsed",
-    "when": "editorTextFocus"
+    "when": "editorTextFocus && vim.mode == 'Normal'"
   },
   // Fuzzy search workspace files
   {
     "key": "space k",
     "command": "workbench.action.quickOpen",
-    "when": "editorTextFocus"
+    "when": "editorTextFocus && vim.mode == 'Normal'"
   },
   // Scroll up 16 Lines
   // Matches Nvim where small scrolls will keep the cursor in exacty the same relative place on the screen


### PR DESCRIPTION
## Summary
- scope VS Code `space` leader keybindings to Vim normal mode

## Testing
- `chezmoi apply --dry-run -S .`
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_68917d75a644832494b2b907a0162762