### PR TITLE
feat(nvim): bootstrap lazy.nvim

### DIFF
--- a/dot_config/nvim/init.lua
+++ b/dot_config/nvim/init.lua
@@ -1,4 +1,17 @@
-vim.opt.rtp:prepend("~/.local/share/nvim/site/pack/lazy/start/lazy.nvim")
+-- bootstrap lazy.nvim --------------------------------------------------------
+local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
+if not vim.loop.fs_stat(lazypath) then
+  vim.fn.system({
+    "git",
+    "clone",
+    "--filter=blob:none",
+    "https://github.com/folke/lazy.nvim.git",
+    "--branch=stable",
+    lazypath,
+  })
+end
+vim.opt.rtp:prepend(lazypath)
+-------------------------------------------------------------------------------
 
 require("plugins")
 


### PR DESCRIPTION
## Summary
- bootstrap lazy.nvim plugin manager in init.lua

## Testing
- `XDG_CONFIG_HOME=/workspace/dotfiles/dot_config nvim --headless -c 'lua print("ok")' -c q`

------
https://chatgpt.com/codex/tasks/task_e_68917dcb2f508324a2b28af8ffc911f7