### PR TITLE
Disable VS Code AI suggestions and use auto-close-tag extension

### DIFF
--- a/.chezmoitemplates/vscode-settings.json
+++ b/.chezmoitemplates/vscode-settings.json
@@ -15,6 +15,11 @@
     "editorCursor.background": "#000000"
   },
 
+  // Disable AI code suggestions and built-in tag closing
+  "editor.inlineSuggest.enabled": false,
+  "github.copilot.enable": { "*": false },
+  "html.autoClosingTags": false,
+
   // Vim extension settings
   "vim.useSystemClipboard": true,
   "vim.useCtrlKeys": true,

--- a/vscode_extensions.txt
+++ b/vscode_extensions.txt
@@ -1,2 +1,3 @@
 vscodevim.vim
 qufiwefefwoyn.kanagawa
+formulahendry.auto-close-tag


### PR DESCRIPTION
## Summary
- Disable inline AI suggestions and Copilot integration in VS Code settings
- Turn off built-in HTML auto-closing and rely on auto-close-tag extension
- Add auto-close-tag extension to VS Code extension list

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891818a2fc8832496d031b9ffaa4cc3