### PR TITLE
feat(vscode): add lazyvim window management keys

### DIFF
--- a/.chezmoitemplates/vscode-keybindings.json
+++ b/.chezmoitemplates/vscode-keybindings.json
@@ -439,5 +439,40 @@
   {
     "key": "ctrl+l",
     "command": "workbench.action.focusRightGroup"
+  },
+  {
+    "key": "ctrl+up",
+    "command": "workbench.action.increaseViewSize",
+    "when": "editorTextFocus && vim.mode == 'Normal'"
+  },
+  {
+    "key": "ctrl+down",
+    "command": "workbench.action.decreaseViewSize",
+    "when": "editorTextFocus && vim.mode == 'Normal'"
+  },
+  {
+    "key": "ctrl+left",
+    "command": "workbench.action.decreaseViewSize",
+    "when": "editorTextFocus && vim.mode == 'Normal'"
+  },
+  {
+    "key": "ctrl+right",
+    "command": "workbench.action.increaseViewSize",
+    "when": "editorTextFocus && vim.mode == 'Normal'"
+  },
+  {
+    "key": "space -",
+    "command": "workbench.action.splitEditorDown",
+    "when": "editorTextFocus && vim.mode == 'Normal'"
+  },
+  {
+    "key": "space |",
+    "command": "workbench.action.splitEditorRight",
+    "when": "editorTextFocus && vim.mode == 'Normal'"
+  },
+  {
+    "key": "space w d",
+    "command": "workbench.action.closeActiveEditor",
+    "when": "editorTextFocus && vim.mode == 'Normal'"
   }
 ]


### PR DESCRIPTION
## Summary
- align VS Code keybindings with LazyVim window navigation and window management

## Testing
- `python - <<'PY'
import re, json
text=re.sub(r'//.*','',open('.chezmoitemplates/vscode-keybindings.json').read())
json.loads(text)
print('JSON parsed successfully')
PY`

------
https://chatgpt.com/codex/tasks/task_e_6891859bd7fc8324b037102619d3d71b