### PR TITLE
Add Kitty terminal installation for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Dotfiles
 
-Personal dotfiles for my development environment, managed with [chezmoi](https://www.chezmoi.io/). Chezmoi bootstraps a vanilla [LazyVim](https://lazyvim.github.io) configuration for Neovim and also sets up tools like Helix, VS Code, and more so they can be reproduced on any machine.
+Personal dotfiles for my development environment, managed with [chezmoi](https://www.chezmoi.io/). Chezmoi bootstraps a vanilla [LazyVim](https://lazyvim.github.io) configuration for Neovim and also sets up tools like Helix, Kitty, VS Code, and more so they can be reproduced on any machine.
 
 ## Installation with chezmoi
 

--- a/run_once_50-install-kitty.sh.tmpl
+++ b/run_once_50-install-kitty.sh.tmpl
@@ -1,0 +1,15 @@
+{{ if eq .chezmoi.os "darwin" -}}
+#!/usr/bin/env bash
+set -e
+
+# Install kitty terminal on macOS if not already installed
+if command -v kitty >/dev/null 2>&1; then
+    exit 0
+fi
+
+if command -v brew >/dev/null 2>&1; then
+    brew install --cask kitty
+else
+    echo "Homebrew not found, unable to install kitty"
+fi
+{{ end -}}


### PR DESCRIPTION
## Summary
- install Kitty via Homebrew on macOS through a new run-once script
- mention Kitty in the README

## Testing
- `bash -n` on the rendered installation script

------
https://chatgpt.com/codex/tasks/task_e_68918b8deda083249399a5015e143c55