### PR TITLE
feat: add which-key extension for VS Code

### DIFF
--- a/.chezmoitemplates/vscode-settings.json
+++ b/.chezmoitemplates/vscode-settings.json
@@ -19,6 +19,7 @@
   "editor.inlineSuggest.enabled": false,
   "github.copilot.enable": { "*": false },
   "html.autoClosingTags": false,
+  "whichkey.delay": 0,
 
   // Vim extension settings
   "vim.useSystemClipboard": true,
@@ -40,6 +41,7 @@
     "visualBlock": "block"
   },
   "vim.normalModeKeyBindingsNonRecursive": [
+    { "before": ["<space>"], "commands": ["whichkey.show"] },
     // Misc
     { "before": ["<leader>", "v"], "after": ["<C-v>"] },
     {
@@ -149,6 +151,9 @@
     { "before": ["S"], "commands": ["workbench.action.findInFiles"] },
     { "before": ["Z", "Z"], "commands": ["workbench.action.files.save", "workbench.action.closeActiveEditor"] },
     { "before": ["Z", "Q"], "commands": ["workbench.action.revertAndCloseActiveEditor"] }
+  ],
+  "vim.visualModeKeyBindingsNonRecursive": [
+    { "before": ["<space>"], "commands": ["whichkey.show"] }
   ],
   "vim.insertModeKeyBindings": [
     { "before": ["<Esc>"], "after": ["<Esc>", "<C-g>u"] },

--- a/vscode_extensions.txt
+++ b/vscode_extensions.txt
@@ -1,3 +1,4 @@
 vscodevim.vim
 qufiwefefwoyn.kanagawa
 formulahendry.auto-close-tag
+VSpaceCode.whichkey


### PR DESCRIPTION
## Summary
- integrate VSpaceCode which-key extension
- show which-key popup from <space> in normal and visual modes

## Testing
- `jq . .chezmoitemplates/vscode-settings.json >/dev/null` (fails: Invalid numeric literal)
- `bash -n run_once_40-install-vscode-extensions.sh.tmpl`


------
https://chatgpt.com/codex/tasks/task_e_6891e7fb8f808324875a257466ef9f55