### PR TITLE
Remove which-key plugin for VS Code

### DIFF
--- a/.chezmoitemplates/vscode-settings.json
+++ b/.chezmoitemplates/vscode-settings.json
@@ -22,8 +22,6 @@
   "editor.inlineSuggest.enabled": false,
   "github.copilot.enable": { "*": false },
   "html.autoClosingTags": false,
-  "whichkey.delay": 0,
-
   // Vim extension settings
   "vim.useSystemClipboard": true,
   "vim.useCtrlKeys": true,
@@ -44,7 +42,6 @@
     "visualBlock": "block"
   },
   "vim.normalModeKeyBindingsNonRecursive": [
-    { "before": ["<space>"], "commands": ["whichkey.show"] },
     // Misc
     { "before": ["<leader>", "v"], "after": ["<C-v>"] },
     {
@@ -155,9 +152,7 @@
     { "before": ["Z", "Z"], "commands": ["workbench.action.files.save", "workbench.action.closeActiveEditor"] },
     { "before": ["Z", "Q"], "commands": ["workbench.action.revertAndCloseActiveEditor"] }
   ],
-  "vim.visualModeKeyBindingsNonRecursive": [
-    { "before": ["<space>"], "commands": ["whichkey.show"] }
-  ],
+  "vim.visualModeKeyBindingsNonRecursive": [],
   "vim.insertModeKeyBindings": [
     { "before": ["<Esc>"], "after": ["<Esc>", "<C-g>u"] },
     { "before": ["<C-k>"], "commands": ["editor.action.triggerParameterHints"] }

--- a/vscode_extensions.txt
+++ b/vscode_extensions.txt
@@ -1,4 +1,3 @@
 vscodevim.vim
 qufiwefefwoyn.kanagawa
 formulahendry.auto-close-tag
-VSpaceCode.whichkey


### PR DESCRIPTION
## Summary
- remove VSpaceCode.whichkey extension
- drop whichkey settings and keybindings to use normal Vim leader

## Testing
- `chezmoi doctor > /tmp/chezmoi.log 2>&1 && cat /tmp/chezmoi.log`

------
https://chatgpt.com/codex/tasks/task_e_689218143ea483248419d6689f5d5662