### PR TITLE
Disable cmp in markdown buffers

### DIFF
--- a/dot_config/nvim/ftplugin/markdown.lua
+++ b/dot_config/nvim/ftplugin/markdown.lua
@@ -1,0 +1,4 @@
+local ok, cmp = pcall(require, 'cmp')
+if ok then
+  cmp.setup.buffer({ enabled = false })
+end


### PR DESCRIPTION
## Summary
- add ftplugin for nvim markdown buffers disabling completion

## Testing
- `luac -p dot_config/nvim/ftplugin/markdown.lua`


------
https://chatgpt.com/codex/tasks/task_e_689222fb92ec8324b3bc85356578e670