### PR TITLE
Install JetBrainsMono Nerd Font across tools

### DIFF
--- a/.chezmoitemplates/vscode-settings.json
+++ b/.chezmoitemplates/vscode-settings.json
@@ -6,6 +6,8 @@
   "editor.cursorSmoothCaretAnimation": "off",
   "editor.cursorStyle": "line",
   "editor.fontSize": 14,
+  "editor.fontFamily": "'JetBrainsMono Nerd Font', monospace",
+  "terminal.integrated.fontFamily": "JetBrainsMono Nerd Font",
   "editor.lineNumbers": "relative",
   "editor.renderLineHighlight": "all",
   "workbench.colorTheme": "Kanagawa",

--- a/AppData/Local/Packages/Microsoft.WindowsTerminal_8wekyb3d8bbwe/LocalState/settings.json.tmpl
+++ b/AppData/Local/Packages/Microsoft.WindowsTerminal_8wekyb3d8bbwe/LocalState/settings.json.tmpl
@@ -1,0 +1,10 @@
+{
+    "profiles": {
+        "defaults": {
+            "font": {
+                "face": "JetBrainsMono Nerd Font"
+            }
+        }
+    }
+}
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Dotfiles
 
-Personal dotfiles for my development environment, managed with [chezmoi](https://www.chezmoi.io/). Chezmoi bootstraps a vanilla [LazyVim](https://lazyvim.github.io) configuration for Neovim and also sets up tools like Helix, Kitty, VS Code, and more so they can be reproduced on any machine.
+Personal dotfiles for my development environment, managed with [chezmoi](https://www.chezmoi.io/). Chezmoi bootstraps a vanilla [LazyVim](https://lazyvim.github.io) configuration for Neovim and also sets up tools like Helix, Kitty, VS Code, and more so they can be reproduced on any machine. JetBrainsMono Nerd Font is installed and configured as the default font for VS Code, Windows Terminal, macOS Terminal, and Kitty.
 
 ## Installation with chezmoi
 

--- a/dot_config/kitty/kitty.conf
+++ b/dot_config/kitty/kitty.conf
@@ -1,0 +1,6 @@
+# Kitty terminal configuration
+font_family JetBrainsMono Nerd Font
+bold_font JetBrainsMono Nerd Font Bold
+italic_font JetBrainsMono Nerd Font Italic
+bold_italic_font JetBrainsMono Nerd Font Bold Italic
+

--- a/run_once_10-install-jetbrainsmono-nerd-font.ps1.tmpl
+++ b/run_once_10-install-jetbrainsmono-nerd-font.ps1.tmpl
@@ -1,0 +1,11 @@
+{{ if eq .chezmoi.os "windows" -}}
+# Install JetBrainsMono Nerd Font on Windows
+if (Get-Command winget -ErrorAction SilentlyContinue) {
+    winget install -e --id NerdFonts.JetBrainsMono
+} elseif (Get-Command choco -ErrorAction SilentlyContinue) {
+    choco install -y nerd-fonts-jetbrainsmono
+} else {
+    Write-Output "No package manager found to install JetBrainsMono Nerd Font"
+}
+{{ end -}}
+

--- a/run_once_10-install-jetbrainsmono-nerd-font.sh.tmpl
+++ b/run_once_10-install-jetbrainsmono-nerd-font.sh.tmpl
@@ -1,0 +1,41 @@
+{{ if ne .chezmoi.os "windows" -}}
+#!/usr/bin/env bash
+set -e
+
+# Install JetBrainsMono Nerd Font if not already installed
+if fc-list | grep -qi "JetBrainsMono Nerd Font"; then
+    exit 0
+fi
+
+if command -v brew >/dev/null 2>&1; then
+    brew tap homebrew/cask-fonts
+    brew install --cask font-jetbrains-mono-nerd-font
+elif command -v apt-get >/dev/null 2>&1; then
+    sudo apt-get update
+    sudo apt-get install -y unzip curl
+    FONT_DIR="$HOME/.local/share/fonts"
+    mkdir -p "$FONT_DIR"
+    curl -fLo /tmp/JetBrainsMono.zip https://github.com/ryanoasis/nerd-fonts/releases/latest/download/JetBrainsMono.zip
+    unzip -o /tmp/JetBrainsMono.zip -d "$FONT_DIR"
+    fc-cache -f
+elif command -v pacman >/dev/null 2>&1; then
+    sudo pacman --noconfirm -S nerd-fonts-jetbrains-mono || true
+elif command -v dnf >/dev/null 2>&1; then
+    sudo dnf install -y jetbrains-mono-nerd-fonts || true
+else
+    echo "No supported package manager found for JetBrainsMono Nerd Font installation."
+fi
+
+# Configure macOS Terminal to use JetBrainsMono Nerd Font
+if [ "{{ .chezmoi.os }}" = "darwin" ]; then
+    osascript <<'AS'
+    tell application "Terminal"
+        set font name of settings set "Basic" to "JetBrainsMono Nerd Font"
+        set font size of settings set "Basic" to 13
+        set default settings to settings set "Basic"
+        set startup settings to settings set "Basic"
+    end tell
+AS
+fi
+{{ end -}}
+


### PR DESCRIPTION
## Summary
- install JetBrainsMono Nerd Font via run-once scripts
- default JetBrainsMono Nerd Font in VS Code, Windows Terminal, macOS Terminal, and Kitty

## Testing
- `shellcheck run_once_10-install-jetbrainsmono-nerd-font.sh.tmpl` *(fails: SC1054, SC1083 due to template braces)*
- `jq . AppData/Local/Packages/Microsoft.WindowsTerminal_8wekyb3d8bbwe/LocalState/settings.json.tmpl`
- `jq . .chezmoitemplates/vscode-settings.json` *(fails: Invalid numeric literal)*
- `sudo apt-get install -y powershell` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68925333dad48324956197fe843b01cd