### PR TITLE
feat(vsvim): allow vag to select entire buffer

### DIFF
--- a/dot_vsvimrc
+++ b/dot_vsvimrc
@@ -51,6 +51,7 @@ nnoremap <Right> l
 
 " Select the entire buffer
 nnoremap vig ggVG
+nnoremap vag ggVG
 " Copy the entire buffer to the clipboard
 nnoremap yig ggVGy
 


### PR DESCRIPTION
## Summary
- allow `vag` to select the entire file so both `vig` and `vag` cover whole buffer

## Testing
- `chezmoi --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68926931fd9483248e2ed338a8b0197e