### PR TITLE
feat(nvim): save file with ctrl-s

### DIFF
--- a/dot_config/nvim/lua/config/keymaps.lua
+++ b/dot_config/nvim/lua/config/keymaps.lua
@@ -1,0 +1,13 @@
+-- Custom keymaps
+-- Save file with <C-s> or, on macOS, <D-s>
+local modes = { "n", "i", "x", "s" }
+
+vim.keymap.set(modes, "<C-s>", function()
+  vim.cmd("silent! write")
+end, { desc = "Save file" })
+
+if vim.fn.has("mac") == 1 then
+  vim.keymap.set(modes, "<D-s>", function()
+    vim.cmd("silent! write")
+  end, { desc = "Save file" })
+end


### PR DESCRIPTION
## Summary
- map ctrl-s/cmd-s to silently write buffer in Neovim

## Testing
- `nvim --headless -u NONE -c "luafile dot_config/nvim/lua/config/keymaps.lua" -c "nmap <C-s>" -c "nmap <D-s>" -c q`
- `nvim --headless -u NONE -c "luafile dot_config/nvim/lua/config/keymaps.lua" -c "imap <C-s>" -c q`


------
https://chatgpt.com/codex/tasks/task_e_6892da69d8c08324ad00dab7ff47b797