### PR TITLE
fix: update JetBrains Mono install script

### DIFF
--- a/run_once_10-install-jetbrainsmono-nerd-font.sh.tmpl
+++ b/run_once_10-install-jetbrainsmono-nerd-font.sh.tmpl
@@ -3,12 +3,17 @@
 set -e
 
 # Install JetBrainsMono Nerd Font if not already installed
-if fc-list | grep -qi "JetBrainsMono Nerd Font"; then
-    exit 0
+if command -v fc-list >/dev/null 2>&1; then
+    if fc-list | grep -qi "JetBrainsMono Nerd Font"; then
+        exit 0
+    fi
+elif [ "$(uname)" = "Darwin" ]; then
+    if ls "$HOME/Library/Fonts" 2>/dev/null | grep -qi "JetBrainsMono Nerd Font"; then
+        exit 0
+    fi
 fi
 
 if command -v brew >/dev/null 2>&1; then
-    brew tap homebrew/cask-fonts
     brew install --cask font-jetbrains-mono-nerd-font
 elif command -v apt-get >/dev/null 2>&1; then
     sudo apt-get update


### PR DESCRIPTION
## Summary
- avoid failing when `fc-list` isn't available by checking fonts directory on macOS
- remove deprecated Homebrew tap for cask-fonts

## Testing
- `bash -n /tmp/script.sh`


------
https://chatgpt.com/codex/tasks/task_e_6892e20348548324808b4e512a087dee