### PR TITLE
docs: clarify windows installation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,10 @@ chezmoi apply
 
 ### Windows
 
+Run PowerShell as Administrator. Before running the scripts, set the execution policy for the current process:
+
 ```powershell
+Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
 winget install twpayne.chezmoi
 chezmoi init F286
 # Review changes if desired


### PR DESCRIPTION
## Summary
- clarify Windows installation by instructing users to run PowerShell as administrator and set execution policy before running scripts

## Testing
- `markdownlint README.md --disable MD013`

------
https://chatgpt.com/codex/tasks/task_e_689374c943f08324b77a66b51529dfcc