### PR TITLE
chore: install ripgrep automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Dotfiles
 
-Personal dotfiles for my development environment, managed with [chezmoi](https://www.chezmoi.io/). Chezmoi bootstraps a vanilla [LazyVim](https://lazyvim.github.io) configuration for Neovim and also sets up tools like Helix, Kitty, VS Code, and more so they can be reproduced on any machine. JetBrainsMono Nerd Font is installed and configured as the default font for VS Code, Windows Terminal, macOS Terminal, and Kitty.
+Personal dotfiles for my development environment, managed with [chezmoi](https://www.chezmoi.io/). Chezmoi bootstraps a vanilla [LazyVim](https://lazyvim.github.io) configuration for Neovim and also sets up tools like Ripgrep, Helix, Kitty, VS Code, and more so they can be reproduced on any machine. JetBrainsMono Nerd Font is installed and configured as the default font for VS Code, Windows Terminal, macOS Terminal, and Kitty.
 
 ## Installation with chezmoi
 

--- a/run_once_60-install-ripgrep.ps1.tmpl
+++ b/run_once_60-install-ripgrep.ps1.tmpl
@@ -1,0 +1,14 @@
+{{ if eq .chezmoi.os "windows" -}}
+if (Get-Command rg -ErrorAction SilentlyContinue) {
+    exit 0
+}
+if (Get-Command winget -ErrorAction SilentlyContinue) {
+    winget install --id BurntSushi.ripgrep.MSVC -e
+} elseif (Get-Command scoop -ErrorAction SilentlyContinue) {
+    scoop install ripgrep
+} elseif (Get-Command choco -ErrorAction SilentlyContinue) {
+    choco install ripgrep -y
+} else {
+    Write-Output "No supported package manager found for ripgrep installation."
+}
+{{ end -}}

--- a/run_once_60-install-ripgrep.sh.tmpl
+++ b/run_once_60-install-ripgrep.sh.tmpl
@@ -1,0 +1,19 @@
+{{ if ne .chezmoi.os "windows" -}}
+#!/usr/bin/env bash
+set -e
+if command -v rg >/dev/null 2>&1; then
+    exit 0
+fi
+if command -v brew >/dev/null 2>&1; then
+    brew install ripgrep
+elif command -v apt-get >/dev/null 2>&1; then
+    sudo apt-get update
+    sudo apt-get install -y ripgrep
+elif command -v pacman >/dev/null 2>&1; then
+    sudo pacman --noconfirm -S ripgrep
+elif command -v dnf >/dev/null 2>&1; then
+    sudo dnf install -y ripgrep
+else
+    echo "No supported package manager found for ripgrep installation."
+fi
+{{ end -}}


### PR DESCRIPTION
## Summary
- ensure ripgrep is installed on macOS/Linux via run-once script
- ensure ripgrep is installed on Windows via run-once script
- document ripgrep as part of bootstrapped tools

## Testing
- `shellcheck run_once_60-install-ripgrep.sh.tmpl` *(fails: needs a space after `{` due to chezmoi templating)*
- `sudo apt-get install -y powershell` *(fails: Unable to locate package powershell)*
- `pwsh -NoLogo -NoProfile -Command "Write-Output test"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68937a5adf948324b3058191a604461b