### PR TITLE
Map leader shortcuts for file navigation and search

### DIFF
--- a/dot_vsvimrc
+++ b/dot_vsvimrc
@@ -88,7 +88,10 @@ vnoremap < <gv
 vnoremap > >gv
 
 " Fuzzy search files
-nnoremap <leader><leader> :vsc ReSharper.ReSharper_GotoFile<CR>
+nnoremap <leader><leader> :vsc Edit.GoToFile<CR>
+
+" Interactive global search
+nnoremap <leader>/ :vsc Edit.FindInFiles<CR>
 
 " This is a workaround for a bug in the 'Save on Format' plugin where cursor moves up one position on save
 nnoremap <C-s> :vsc Edit.FormatDocument<CR>:vsc File.SaveAll<CR><Right>


### PR DESCRIPTION
## Summary
- Map `<leader><leader>` to Visual Studio's `Edit.GoToFile` command
- Add `<leader>/` mapping for `Edit.FindInFiles` to run a global search

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894bf696f48832482fb157a6bb92ffb