### PR TITLE
Use panel for VS Code search

### DIFF
--- a/.chezmoitemplates/vscode-settings.json
+++ b/.chezmoitemplates/vscode-settings.json
@@ -20,6 +20,8 @@
     "editor.background": "#222436"
   },
 
+  "search.location": "panel",
+
   // Disable AI code suggestions and built-in tag closing
   "editor.inlineSuggest.enabled": false,
   "github.copilot.enable": { "*": false },


### PR DESCRIPTION
## Summary
- show VS Code search as a panel instead of a docked sidebar

## Testing
- `chezmoi doctor` *(fails: command not found)*
- `apt-get install -y chezmoi` *(fails: Unable to locate package)*
- `jq . .chezmoitemplates/vscode-settings.json` *(fails: Invalid numeric literal at line 2, column 5)*

------
https://chatgpt.com/codex/tasks/task_e_6894c8f75ab48324916d3979afab1ab0