### PR TITLE
Fix leader slash mapping to avoid Vim search

### DIFF
--- a/dot_vsvimrc
+++ b/dot_vsvimrc
@@ -91,7 +91,8 @@ vnoremap > >gv
 nnoremap <leader><leader> :vsc Edit.GoToFile<CR>
 
 " All-in-one text search
-nnoremap <leader>/ :vsc Edit.GoToAll<CR>x:
+" Use Find in Files and avoid triggering Vim's search
+nnoremap <silent> <leader>/ :vsc Edit.FindinFiles<CR>
 
 " All-in-one type search
 nnoremap <leader>st :vsc Edit.GoToAll<CR>t:


### PR DESCRIPTION
## Summary
- Use Visual Studio's `Edit.FindinFiles` for `<leader>/` to avoid triggering Vim search

## Testing
- `pre-commit run --files dot_vsvimrc` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894cfcaa8b4832488b241ce7d1ff307