### PR TITLE
feat: map gcc comment toggle across editors

### DIFF
--- a/.chezmoitemplates/vscode-keybindings.json
+++ b/.chezmoitemplates/vscode-keybindings.json
@@ -190,6 +190,12 @@
     "command": "editor.action.commentLine",
     "when": "editorTextFocus"
   },
+  {
+    // LazyVim-style line comment
+    "key": "g c c",
+    "command": "editor.action.commentLine",
+    "when": "editorTextFocus && vim.mode == 'Normal'"
+  },
   // Change within current file
   // Makes the standard cmd-f shortcut map to the / key
   // Useful as I have a macro mapped to cmd-f

--- a/dot_vsvimrc
+++ b/dot_vsvimrc
@@ -122,7 +122,8 @@ nnoremap gr :vsc Edit.FindAllReferences<CR>
 nnoremap gk :vsc Edit.PreviousMethod<CR>
 nnoremap gj :vsc Edit.NextMethod<CR>
 nnoremap gu :vsc ReSharper.ReSharper_GotoUsage<CR>
-nnoremap gc :vsc Edit.ToggleComment<CR>
+" Toggle comment like LazyVim's gcc mapping
+nnoremap gcc :vsc Edit.ToggleComment<CR>
 nnoremap gh :vsc EditorContextMenus.CodeWindow.ToggleHeaderCodeFile<CR>
 
 " Code


### PR DESCRIPTION
## Summary
- map `gcc` to toggle comments in Visual Studio's VsVim
- add `g c c` keybinding in VS Code to toggle line comments

## Testing
- `vint dot_vsvimrc` *(fails: ModuleNotFoundError: No module named 'cerf_api')*
- `jq . .chezmoitemplates/vscode-keybindings.json` *(fails: parse error: Invalid numeric literal at line 1, column 3)*

------
https://chatgpt.com/codex/tasks/task_e_6894d9d8f6b08324bbbed8569eb95acc