### PR TITLE
Center VS Code quick input

### DIFF
--- a/.chezmoitemplates/vscode-settings.json
+++ b/.chezmoitemplates/vscode-settings.json
@@ -20,6 +20,8 @@
     "editor.background": "#222436"
   },
 
+  "workbench.quickOpen.centered": true,
+
   "search.location": "panel",
 
   // Disable AI code suggestions and built-in tag closing


### PR DESCRIPTION
## Summary
- center VS Code quick input overlay

## Testing
- `apt-get install -y chezmoi` *(failed: Unable to locate package chezmoi)*
- `jq empty .chezmoitemplates/vscode-settings.json` *(failed: Invalid numeric literal at line 2, column 5)*

------
https://chatgpt.com/codex/tasks/task_e_6896c34d17d88324a71ef902771d4e09