### PR TITLE
Add multi-command extension and sidebar keybindings

### DIFF
--- a/.chezmoitemplates/vscode-keybindings.json
+++ b/.chezmoitemplates/vscode-keybindings.json
@@ -453,5 +453,17 @@
     "key": "ctrl+right",
     "command": "workbench.action.increaseViewSize",
     "when": "editorTextFocus && vim.mode == 'Normal'"
+  },
+  // First press: show + focus (focus command auto-opens if hidden)
+  {
+    "key": "ctrl+]",
+    "command": "multiCommand.showAndFocusSecondarySideBar",
+    "when": "!secondarySideBarVisible"
+  },
+  // Second press: hide
+  {
+    "key": "ctrl+]",
+    "command": "workbench.action.toggleSecondarySideBar",
+    "when": "secondarySideBarVisible"
   }
 ]

--- a/.chezmoitemplates/vscode-settings.json
+++ b/.chezmoitemplates/vscode-settings.json
@@ -196,5 +196,14 @@
     { "before": ["J"], "commands": ["editor.action.moveLinesDownAction"] },
     { "before": ["K"], "commands": ["editor.action.moveLinesUpAction"] }
   ],
+  // Multi-command configuration for secondary side bar toggle+focus
+  "multiCommand.commands": [
+    {
+      "command": "multiCommand.showAndFocusSecondarySideBar",
+      "sequence": [
+        "workbench.action.focusIntoSecondarySideBar"
+      ]
+    }
+  ],
   "keyboard.dispatch": "keyCode"
 }

--- a/vscode_extensions.txt
+++ b/vscode_extensions.txt
@@ -1,3 +1,4 @@
 vscodevim.vim
 qufiwefefwoyn.kanagawa
 formulahendry.auto-close-tag
+ryuta46.multi-command


### PR DESCRIPTION
## Summary
- add multi-command extension to VS Code setup
- configure multiCommand to focus the secondary side bar
- bind Ctrl+] to toggle and focus the secondary side bar

## Testing
- `python - <<'PY'
import json5, sys
for path in ['.chezmoitemplates/vscode-settings.json', '.chezmoitemplates/vscode-keybindings.json']:
    json5.load(open(path))
print('JSON5 parse ok')
PY`


------
https://chatgpt.com/codex/tasks/task_e_6896cf7cc7608324bc1bafa6eb3fda1a