### PR TITLE
Remove multi-command plugin and update VS Code sidebar toggle

### DIFF
--- a/.chezmoitemplates/vscode-keybindings.json
+++ b/.chezmoitemplates/vscode-keybindings.json
@@ -454,16 +454,20 @@
     "command": "workbench.action.increaseViewSize",
     "when": "editorTextFocus && vim.mode == 'Normal'"
   },
-  // First press: show + focus (focus command auto-opens if hidden)
+  // ⌘] — smart toggle for the Secondary Side Bar (a.k.a. Auxiliary Bar)
   {
-    "key": "ctrl+]",
-    "command": "multiCommand.showAndFocusSecondarySideBar",
-    "when": "!secondarySideBarVisible"
+    "key": "cmd+]",
+    "command": "workbench.action.focusAuxiliaryBar",
+    "when": "!auxiliaryBarVisible"
   },
-  // Second press: hide
   {
-    "key": "ctrl+]",
-    "command": "workbench.action.toggleSecondarySideBar",
-    "when": "secondarySideBarVisible"
+    "key": "cmd+]",
+    "command": "workbench.action.focusAuxiliaryBar",
+    "when": "auxiliaryBarVisible && !auxiliaryBarFocus"
+  },
+  {
+    "key": "cmd+]",
+    "command": "workbench.action.toggleAuxiliaryBar",
+    "when": "auxiliaryBarFocus"
   }
 ]

--- a/.chezmoitemplates/vscode-settings.json
+++ b/.chezmoitemplates/vscode-settings.json
@@ -196,14 +196,5 @@
     { "before": ["J"], "commands": ["editor.action.moveLinesDownAction"] },
     { "before": ["K"], "commands": ["editor.action.moveLinesUpAction"] }
   ],
-  // Multi-command configuration for secondary side bar toggle+focus
-  "multiCommand.commands": [
-    {
-      "command": "multiCommand.showAndFocusSecondarySideBar",
-      "sequence": [
-        "workbench.action.focusIntoSecondarySideBar"
-      ]
-    }
-  ],
   "keyboard.dispatch": "keyCode"
 }

--- a/vscode_extensions.txt
+++ b/vscode_extensions.txt
@@ -1,4 +1,3 @@
 vscodevim.vim
 qufiwefefwoyn.kanagawa
 formulahendry.auto-close-tag
-ryuta46.multi-command


### PR DESCRIPTION
## Summary
- drop multi-command extension and its config
- replace `Ctrl+]` multi-command macro with native `Cmd+]` auxiliary bar toggle

## Testing
- `node -e 'const fs=require("fs");const data=fs.readFileSync(".chezmoitemplates/vscode-settings.json","utf8").replace(/\/\/.*$/mg,""); JSON.parse(data);'`
- `node -e 'const fs=require("fs");const data=fs.readFileSync(".chezmoitemplates/vscode-keybindings.json","utf8").replace(/\/\/.*$/mg,""); JSON.parse(data);'`


------
https://chatgpt.com/codex/tasks/task_e_68983ec5294c83248a1d9941d2bb0c95