### PR TITLE
feat: map gc to toggle comments

### DIFF
--- a/.chezmoitemplates/vscode-keybindings.json
+++ b/.chezmoitemplates/vscode-keybindings.json
@@ -4,6 +4,18 @@
   { "key": "alt+down", "command": "-editor.action.moveLinesDownAction" },
   { "key": "alt+up", "command": "-editor.action.moveLinesUpAction" },
 
+  // Toggle line comment with gc in VSCodeVim
+  {
+    "key": "g c",
+    "command": "editor.action.commentLine",
+    "when": "editorTextFocus && vim.mode == 'Normal'"
+  },
+  {
+    "key": "g c",
+    "command": "editor.action.commentLine",
+    "when": "editorTextFocus && (vim.mode == 'Visual' || vim.mode == 'VisualLine' || vim.mode == 'VisualBlock')"
+  },
+
   // Page Down - workround to make cursor movement match Nvim
   {
     "key": "pagedown",

--- a/dot_config/nvim/lua/config/keymaps.lua
+++ b/dot_config/nvim/lua/config/keymaps.lua
@@ -11,3 +11,6 @@ if vim.fn.has("mac") == 1 then
     vim.cmd("silent! write")
   end, { desc = "Save file" })
 end
+
+-- Toggle comment on current line with gc in normal mode
+vim.keymap.set("n", "gc", "gcc", { remap = true, silent = true, desc = "Comment current line (gc)" })


### PR DESCRIPTION
## Summary
- Map `gc` to VS Code's line comment command for Normal and Visual modes
- Mirror `gc` behavior in Neovim by remapping to `gcc`

## Testing
- `chezmoi --version` *(fails: command not found)*
- `apt-get install -y chezmoi` *(fails: Unable to locate package)*
- `nvim --version`
- `nvim --headless +'luafile dot_config/nvim/lua/config/keymaps.lua' +qa`


------
https://chatgpt.com/codex/tasks/task_e_689971c81f1c8324a821372e7e29423a