### PR TITLE
feat: enable highlighted yank in VS Code

### DIFF
--- a/.chezmoitemplates/vscode-settings.json
+++ b/.chezmoitemplates/vscode-settings.json
@@ -34,6 +34,9 @@
   "vim.surround": true,
   "vim.leader": " ",
   "vim.hlsearch": true,
+  "vim.highlightedyank.enable": true,
+  "vim.highlightedyank.color": "rgba(255, 223, 93, 0.3)", // warm gold, soft opacity
+  "vim.highlightedyank.duration": 290, // milliseconds
   "vim.handleKeys": {
     "<tab>": false,
     "<S-tab>": false,


### PR DESCRIPTION
## Summary
- enable highlight on yank in VS Code Vim extension

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_689976ad4738832486a1cd30038d509d