### PR TITLE
feat: scroll copilot chat with vim keys

### DIFF
--- a/.chezmoitemplates/vscode-keybindings.json
+++ b/.chezmoitemplates/vscode-keybindings.json
@@ -470,6 +470,18 @@
   { "key": "cmd+j", "command": "workbench.action.focusPanel", "when": "!panelFocus" },
   { "key": "cmd+j", "command": "workbench.action.closePanel",  "when": "panelFocus" },
 
+  // Scroll Copilot Chat list with Vim-style keys
+  {
+    "key": "ctrl+d",
+    "command": "list.focusPageDown",
+    "when": "auxiliaryBarFocus && listFocus && !inputFocus"
+  },
+  {
+    "key": "ctrl+u",
+    "command": "list.focusPageUp",
+    "when": "auxiliaryBarFocus && listFocus && !inputFocus"
+  },
+
   // Right (Secondary) Side Bar — single ⌘ stroke
   { "key": "cmd+;", "command": "workbench.action.focusAuxiliaryBar",   "when": "!auxiliaryBarFocus" },
   { "key": "cmd+;", "command": "workbench.action.toggleAuxiliaryBar",  "when": "auxiliaryBarFocus" },


### PR DESCRIPTION
## Summary
- allow Ctrl+D and Ctrl+U to page through lists in Copilot Chat when the right auxiliary bar is focused

## Testing
- `chezmoi --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689976fdce8083249bf19e662f7b77b9