### PR TITLE
Center VS Code quick input

### DIFF
--- a/.chezmoitemplates/vscode-settings.json
+++ b/.chezmoitemplates/vscode-settings.json
@@ -21,6 +21,7 @@
   },
 
   "workbench.quickOpen.centered": true,
+  "window.commandCenter": false,
 
   "search.location": "panel",
 


### PR DESCRIPTION
## Summary
- disable VS Code Command Center so quick input opens in the middle of the window

## Testing
- `python - <<'PY'
import json, re, pathlib
text = pathlib.Path('.chezmoitemplates/vscode-settings.json').read_text()
text = re.sub(r'//.*', '', text)
json.loads(text)
print('JSON valid')
PY`


------
https://chatgpt.com/codex/tasks/task_e_689a020e90488324be74069eed176054