### PR TITLE
Map Shift-U to redo in VS Code Vim settings

### DIFF
--- a/.chezmoitemplates/vscode-settings.json
+++ b/.chezmoitemplates/vscode-settings.json
@@ -185,6 +185,14 @@
     // Misc
     {
       "before": [
+        "U"
+      ],
+      "after": [
+        "<C-r>"
+      ]
+    },
+    {
+      "before": [
         "<leader>",
         "v"
       ],


### PR DESCRIPTION
## Summary
- map `U` to `<C-r>` for redo in VSCode Vim/Neovim settings

## Testing
- `chezmoi doctor` *(fails: command not found)*
- `apt-get install -y chezmoi` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_689a5cfb5bf0832494403de390d636ee