### PR TITLE
feat: add vscode-textobjects extension

### DIFF
--- a/.chezmoitemplates/vscode-extensions.json
+++ b/.chezmoitemplates/vscode-extensions.json
@@ -2,7 +2,8 @@
   "recommendations": [
     "vscodevim.vim",
     "qufiwefefwoyn.kanagawa",
-    "formulahendry.auto-close-tag"
+    "formulahendry.auto-close-tag",
+    "RodrigoScola.vscode-textobjects"
   ],
   "unwantedRecommendations": []
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,7 +2,8 @@
   "recommendations": [
     "vscodevim.vim",
     "qufiwefefwoyn.kanagawa",
-    "formulahendry.auto-close-tag"
+    "formulahendry.auto-close-tag",
+    "RodrigoScola.vscode-textobjects"
   ],
   "unwantedRecommendations": []
 }


### PR DESCRIPTION
## Summary
- add RodrigoScola.vscode-textobjects to VS Code recommended extensions

## Testing
- `npm test` *(fails: enoent could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689acafcffb48324a36c3f7d014f95be