### PR TITLE
Map j/k to visual line movement in VS Code Vim

### DIFF
--- a/.chezmoitemplates/vscode-settings.json
+++ b/.chezmoitemplates/vscode-settings.json
@@ -52,6 +52,25 @@
     "visualBlock": "block"
   },
   "vim.visualModeKeyBindingsNonRecursive": [
+    // Navigate by visual lines
+    {
+      "before": [
+        "j"
+      ],
+      "after": [
+        "g",
+        "j"
+      ]
+    },
+    {
+      "before": [
+        "k"
+      ],
+      "after": [
+        "g",
+        "k"
+      ]
+    },
     {
       "before": [
         "leader",
@@ -163,6 +182,25 @@
   "keyboard.dispatch": "keyCode",
   "vscode-textobjects.vimEnabled": true,
   "vim.normalModeKeyBindingsNonRecursive": [
+    // Navigate by visual lines
+    {
+      "before": [
+        "j"
+      ],
+      "after": [
+        "g",
+        "j"
+      ]
+    },
+    {
+      "before": [
+        "k"
+      ],
+      "after": [
+        "g",
+        "k"
+      ]
+    },
     // Window splits
     {
       "before": [


### PR DESCRIPTION
## Summary
- make `j` and `k` navigate by visual lines in VS Code Vim's normal and visual modes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689acb35a4d8832489c9ee9dfb271421