### PR TITLE
feat: customize VS Code selection color

### DIFF
--- a/.chezmoitemplates/vscode-settings.json
+++ b/.chezmoitemplates/vscode-settings.json
@@ -18,6 +18,7 @@
     "editorCursor.background": "#000000",
     "editor.lineHighlightBackground": "#2F334D",
     "editorLineNumber.activeForeground": "#FF9E3B",
+    "editor.selectionBackground": "#313F72",
     "editor.background": "#222436"
   },
   "workbench.quickOpen.centered": true,


### PR DESCRIPTION
## Summary
- adjust VS Code template to use #313F72 for text selection

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/dotfiles/package.json')*
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_689ad52467c8832480ffb5299096887a