### PR TITLE
feat: add ctrl scroll keybindings in VS Code

### DIFF
--- a/.chezmoitemplates/vscode-keybindings.json
+++ b/.chezmoitemplates/vscode-keybindings.json
@@ -166,6 +166,91 @@
         "scrollLineDown",
         "cursorDown",
         "scrollLineDown",
+      "cursorDown"
+      ]
+    }
+  },
+  // Scroll up 16 Lines
+  // Matches Nvim where small scrolls will keep the cursor in exacty the same relative place on the screen
+  {
+    "key": "ctrl+u",
+    "command": "runCommands",
+    "when": "textInputFocus",
+    "args": {
+      "commands": [
+        "scrollLineUp",
+        "cursorUp",
+        "scrollLineUp",
+        "cursorUp",
+        "scrollLineUp",
+        "cursorUp",
+        "scrollLineUp",
+        "cursorUp",
+        "scrollLineUp",
+        "cursorUp",
+        "scrollLineUp",
+        "cursorUp",
+        "scrollLineUp",
+        "cursorUp",
+        "scrollLineUp",
+        "cursorUp",
+        "scrollLineUp",
+        "cursorUp",
+        "scrollLineUp",
+        "cursorUp",
+        "scrollLineUp",
+        "cursorUp",
+        "scrollLineUp",
+        "cursorUp",
+        "scrollLineUp",
+        "cursorUp",
+        "scrollLineUp",
+        "cursorUp",
+        "scrollLineUp",
+        "cursorUp",
+        "scrollLineUp",
+        "cursorUp"
+      ]
+    }
+  },
+  // Scroll down 16 Lines
+  {
+    "key": "ctrl+d",
+    "command": "runCommands",
+    "when": "textInputFocus",
+    "args": {
+      "commands": [
+        "scrollLineDown",
+        "cursorDown",
+        "scrollLineDown",
+        "cursorDown",
+        "scrollLineDown",
+        "cursorDown",
+        "scrollLineDown",
+        "cursorDown",
+        "scrollLineDown",
+        "cursorDown",
+        "scrollLineDown",
+        "cursorDown",
+        "scrollLineDown",
+        "cursorDown",
+        "scrollLineDown",
+        "cursorDown",
+        "scrollLineDown",
+        "cursorDown",
+        "scrollLineDown",
+        "cursorDown",
+        "scrollLineDown",
+        "cursorDown",
+        "scrollLineDown",
+        "cursorDown",
+        "scrollLineDown",
+        "cursorDown",
+        "scrollLineDown",
+        "cursorDown",
+        "scrollLineDown",
+        "cursorDown",
+        "scrollLineDown",
         "cursorDown"
       ]
     }


### PR DESCRIPTION
## Summary
- add ctrl+u binding to scroll up 16 lines, mirroring Nvim small scroll behavior
- add ctrl+d binding to scroll down 16 lines

## Testing
- `python - <<'PY'
import json5, sys
with open('.chezmoitemplates/vscode-keybindings.json') as f:
    json5.load(f)
print('JSON5 parse ok')
PY`


------
https://chatgpt.com/codex/tasks/task_e_689b62b99be0832489541026db8d3868