### PR TITLE
Disable VSCodeVim Ctrl+A interception

### DIFF
--- a/.chezmoitemplates/vscode-settings.json
+++ b/.chezmoitemplates/vscode-settings.json
@@ -47,6 +47,7 @@
     "<C-c>": false,
     "<C-v>": false,
     "<C-x>": false,
+    "<C-a>": false,
     "<D-c>": false,
     "<D-v>": false,
     "<D-x>": false


### PR DESCRIPTION
## Summary
- Allow VS Code to handle Ctrl+A by adding a `<C-a>` entry to the `vim.handleKeys` configuration

## Testing
- `chezmoi apply --source=. --destination="$HOME" -v` *(fails: 20-install-lazyvim.sh: exit status 130)*

------
https://chatgpt.com/codex/tasks/task_e_689ca2ed18d0832488f7ec194139fa31