### PR TITLE
feat: add mac word navigation keybindings

### DIFF
--- a/.chezmoitemplates/vscode-keybindings.json
+++ b/.chezmoitemplates/vscode-keybindings.json
@@ -4,8 +4,32 @@
   // Disable line move shortcuts
   { "key": "alt+down", "command": "-editor.action.moveLinesDownAction" },
   { "key": "alt+up", "command": "-editor.action.moveLinesUpAction" },
+{{- if eq .chezmoi.os "darwin" }}
+  // ----- Word navigation on ⌘ + ← / → -----
+  // Remove defaults (line start/end) that would conflict:
+  { "key": "cmd+left",  "command": "-cursorHome", "when": "editorTextFocus" },
+  { "key": "cmd+right", "command": "-cursorEnd",  "when": "editorTextFocus" },
 
-  
+  // New behavior: jump by word
+  { "key": "cmd+left",  "command": "cursorWordStartLeft", "when": "editorTextFocus" },
+  { "key": "cmd+right", "command": "cursorWordEndRight",  "when": "editorTextFocus" },
+
+  // ----- Word deletion on ⌘ + Backspace / Delete -----
+  // Remove defaults (delete to line start/end):
+  { "key": "cmd+backspace", "command": "-deleteAllLeft",  "when": "editorTextFocus && !editorReadonly" },
+  { "key": "cmd+delete",    "command": "-deleteAllRight", "when": "editorTextFocus && !editorReadonly" },
+
+  // New behavior: delete one word left/right
+  { "key": "cmd+backspace", "command": "deleteWordLeft",  "when": "editorTextFocus && !editorReadonly" },
+  { "key": "cmd+delete",    "command": "deleteWordRight", "when": "editorTextFocus && !editorReadonly" },
+
+  // ----- Selection variants (hold ⇧ to select by word) -----
+  // Shift+Cmd+←/→ selects by word instead of line.
+  { "key": "shift+cmd+left",  "command": "-cursorHomeSelect", "when": "editorTextFocus" },
+  { "key": "shift+cmd+right", "command": "-cursorEndSelect",  "when": "editorTextFocus" },
+  { "key": "shift+cmd+left",  "command": "cursorWordStartLeftSelect", "when": "editorTextFocus" },
+  { "key": "shift+cmd+right", "command": "cursorWordEndRightSelect",  "when": "editorTextFocus" }
+{{- end }}
 
   // Page Down - workround to make cursor movement match Nvim
   {


### PR DESCRIPTION
## Summary
- add macOS-specific VS Code keybindings for word navigation, deletion, and selection

## Testing
- `chezmoi execute-template < .chezmoitemplates/vscode-keybindings.json | head -n 40`


------
https://chatgpt.com/codex/tasks/task_e_689d57357ac48324a897658972261cfb