### PR TITLE
refactor: drop deprecated cask-fonts tap

### DIFF
--- a/.chezmoiscripts/run_once_install-nerd-fonts-darwin.sh.tmpl
+++ b/.chezmoiscripts/run_once_install-nerd-fonts-darwin.sh.tmpl
@@ -2,6 +2,5 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-brew tap homebrew/cask-fonts
 brew install --cask font-jetbrains-mono-nerd-font
 {{- end -}}


### PR DESCRIPTION
## Summary
- remove deprecated homebrew/cask-fonts tap from macOS nerd font installer script

## Testing
- `shellcheck .chezmoiscripts/run_once_install-nerd-fonts-darwin.sh.tmpl` *(fails: SC1054, SC1083 due to chezmoi template braces)*

------
https://chatgpt.com/codex/tasks/task_e_689d652a9b4083248051921ec4dbcad9