### PR TITLE
feat(vscode): add vag buffer text object alias

### DIFF
--- a/.chezmoitemplates/vscode-settings.json
+++ b/.chezmoitemplates/vscode-settings.json
@@ -50,7 +50,8 @@
     "<C-a>": false,
     "<D-c>": false,
     "<D-v>": false,
-    "<D-x>": false
+    "<D-x>": false,
+    "<D-a>": false
   },
   "vim.cursorStylePerMode": {
     "normal": "block",
@@ -60,6 +61,11 @@
     "visualLine": "line-thin",
     "visualBlock": "line-thin"
   },
+  "vim.operatorPendingModeKeyBindingsNonRecursive": [
+    // Entire buffer text object
+    { "before": ["a", "g"], "after": ["a", "e"] },
+    { "before": ["i", "g"], "after": ["i", "e"] }
+  ],
   "vim.visualModeKeyBindingsNonRecursive": [
     // Navigate by visual lines
     {
@@ -99,7 +105,10 @@
       "commands": [
         "editor.action.formatSelection"
       ]
-    }
+    },
+    // Entire buffer text object
+    { "before": ["a", "g"], "after": ["a", "e"] },
+    { "before": ["i", "g"], "after": ["i", "e"] }
   ],
   "vim.insertModeKeyBindingsNonRecursive": [
     {
@@ -268,6 +277,8 @@
         ":nohl"
       ]
     },
+    // Entire buffer text object
+    { "before": ["v", "a", "g"], "after": ["v", "a", "e"] },
     // Moved from keybindings.json: comment toggles
     {
       "before": [


### PR DESCRIPTION
## Summary
- support vag/yag/dag as entire-buffer motions in VS Code's Vim extension
- allow Cmd+A to use VS Code's native Select All when Vim key handling is enabled

## Testing
- `chezmoi --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d7021fba08324bc26029dfb7d6ea1