### PR TITLE
Add macOS word-wise navigation and Hammerspoon setup

### DIFF
--- a/Library/KeyBindings/DefaultKeyBinding.dict
+++ b/Library/KeyBindings/DefaultKeyBinding.dict
@@ -1,0 +1,16 @@
+{
+    /* Cmd+Left/Right → move by word */
+    "@\UF702" = "moveWordBackward:";
+    "@\UF703" = "moveWordForward:";
+
+    /* Cmd+Shift+Left/Right → select by word */
+    "@$\UF702" = "moveWordBackwardAndModifySelection:";
+    "@$\UF703" = "moveWordForwardAndModifySelection:";
+
+    /* Cmd+Delete (backspace) → delete word backward */
+    "@\U0008" = "deleteWordBackward:";
+    "@\U007F" = "deleteWordBackward:";
+
+    /* Cmd+Forward Delete (or Cmd+Fn+Delete on laptops) → delete word forward */
+    "@\UF728" = "deleteWordForward:";
+}

--- a/chezmoiignore.tmpl
+++ b/chezmoiignore.tmpl
@@ -18,3 +18,9 @@ AppData/Roaming/Code/User/keybindings.json
 {{ if ne .chezmoi.os "darwin" }}darwin/**{{ end }}
 {{ if ne .chezmoi.os "linux" }}linux/**{{ end }}
 {{ if ne .chezmoi.os "windows" }}windows/**{{ end }}
+
+{{- if ne .chezmoi.os "darwin" }}
+Library/KeyBindings/**
+dot_hammerspoon/**
+run_once_25-install-hammerspoon.sh.tmpl
+{{- end }}

--- a/dot_hammerspoon/init.lua
+++ b/dot_hammerspoon/init.lua
@@ -1,0 +1,51 @@
+-- Map Cmd+Arrows/Delete to Option equivalents in target apps
+-- Works in Chrome page content; Safari is included as a fallback (remove if not desired).
+
+local targets = {
+  ["com.google.Chrome"] = true,   -- Chrome
+  ["com.apple.Safari"]  = true,   -- Safari (optional)
+  -- Add others if you want:
+  -- ["com.microsoft.edgemac"] = true,
+  -- ["com.brave.Browser"] = true,
+  -- ["company.thebrowser.Browser"] = true, -- Arc
+}
+
+local keyDown   = hs.eventtap.event.types.keyDown
+local keyRepeat = hs.eventtap.event.types.keyRepeat
+
+local function frontIsTarget()
+  local app = hs.application.frontmostApplication()
+  return app and targets[app:bundleID()] == true
+end
+
+local function handle(e)
+  local t = e:getType()
+  if t ~= keyDown and t ~= keyRepeat then return false end
+  if not frontIsTarget() then return false end
+
+  local flags = e:getFlags()
+  -- Only when Command is down (Shift allowed), not when Option/Ctrl already down
+  if not flags.cmd or flags.alt or flags.ctrl then return false end
+
+  local kc = e:getKeyCode()
+  local map = hs.keycodes.map
+  local mods = {"alt"}
+  if flags.shift then table.insert(mods, "shift") end
+
+  if kc == map.left then
+    hs.eventtap.keyStroke(mods, "left", 0)         -- ⌥← or ⌥⇧←
+    return true
+  elseif kc == map.right then
+    hs.eventtap.keyStroke(mods, "right", 0)        -- ⌥→ or ⌥⇧→
+    return true
+  elseif kc == map.delete then
+    hs.eventtap.keyStroke({"alt"}, "delete", 0)    -- ⌥⌫ (delete word backward)
+    return true
+  elseif kc == map.forwarddelete then
+    hs.eventtap.keyStroke({"alt"}, "forwarddelete", 0) -- ⌥ForwardDelete
+    return true
+  end
+  return false
+end
+
+hs.eventtap.new({keyDown, keyRepeat}, handle):start()

--- a/run_once_25-install-hammerspoon.sh.tmpl
+++ b/run_once_25-install-hammerspoon.sh.tmpl
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+{{- if eq .chezmoi.os "darwin" }}
+set -euo pipefail
+
+# Ensure Homebrew exists (skip if not)
+if ! command -v brew >/dev/null 2>&1 ; then
+  echo "[hammerspoon] Homebrew not found; skipping Hammerspoon install."
+  exit 0
+fi
+
+# Install Hammerspoon if absent
+if ! [[ -d "/Applications/Hammerspoon.app" ]] && ! brew list --cask hammerspoon >/dev/null 2>&1 ; then
+  brew install --cask hammerspoon
+fi
+
+echo "[hammerspoon] If this is your first run, open Hammerspoon once and grant Accessibility permissions:"
+echo "             System Settings → Privacy & Security → Accessibility → enable Hammerspoon."
+{{- end }}


### PR DESCRIPTION
## Summary
- map Cmd+arrow/delete to word-wise actions via `DefaultKeyBinding.dict`
- enable word-wise navigation in Chrome/Safari using Hammerspoon
- install Hammerspoon on macOS via run-once script and ignore on other OSes

## Testing
- `luac -p dot_hammerspoon/init.lua`
- `shellcheck run_once_25-install-hammerspoon.sh.tmpl` *(fails: SC1054/SC1083/SC1009/SC1073/SC1056/SC1072 due to Go templating)*
- `shellcheck -e SC1054,SC1083,SC1009,SC1073,SC1056,SC1072 run_once_25-install-hammerspoon.sh.tmpl`


------
https://chatgpt.com/codex/tasks/task_e_689dca838c0c832481a150d5c8aed75e