### PR TITLE
Enable Ctrl/Cmd+V paste in Vim search

### DIFF
--- a/.chezmoitemplates/vscode-settings.json
+++ b/.chezmoitemplates/vscode-settings.json
@@ -45,11 +45,11 @@
     "<C-o>": true,
     "<C-i>": true,
     "<C-c>": false,
-    "<C-v>": false,
+    "<C-v>": true,
     "<C-x>": false,
     "<C-a>": false,
     "<D-c>": false,
-    "<D-v>": false,
+    "<D-v>": true,
     "<D-x>": false,
     "<D-a>": false
   },
@@ -111,6 +111,15 @@
     { "before": ["i", "g"], "after": ["i", "e"] }
   ],
   "vim.insertModeKeyBindingsNonRecursive": [
+    {
+      "before": ["<C-v>"],
+      "commands": ["editor.action.clipboardPasteAction"]
+    },
+    {
+      "before": ["<D-v>"],
+      "commands": ["editor.action.clipboardPasteAction"]
+    },
+
     {
       "before": [
         "<C-k>"


### PR DESCRIPTION
## Summary
- let VSCodeVim handle Ctrl/Cmd+V so pasting works in `/` searches
- add insert-mode bindings for Ctrl/Cmd+V to keep clipboard paste behavior

## Testing
- `python - <<'PY'
import json, re, pathlib
text=pathlib.Path('.chezmoitemplates/vscode-settings.json').read_text(); text=re.sub(r'//.*','',text); json.loads(text); print('JSON parsed')
PY`

------
https://chatgpt.com/codex/tasks/task_e_689df3fa38b4832480ade0e0954b37ce