### PR TITLE
Add WezTerm installer and configuration

### DIFF
--- a/dot_config/wezterm/wezterm.lua.tmpl
+++ b/dot_config/wezterm/wezterm.lua.tmpl
@@ -1,0 +1,41 @@
+-- {{/* Chezmoi template -> renders to ~/.config/wezterm/wezterm.lua */}}
+local wezterm = require("wezterm")
+local act = wezterm.action
+
+-- Prefer config_builder when available (newer WezTerm), else a plain table.
+local config = wezterm.config_builder and wezterm.config_builder() or {}
+
+-- ---- Appearance & font: match your repo's default Nerd Font setup ----
+config.font = wezterm.font_with_fallback({
+  "JetBrainsMono Nerd Font", -- your README states this is the default
+  "SF Mono",
+  "Menlo",
+  "monospace",
+})
+config.font_size = 13.0
+config.hide_tab_bar_if_only_one_tab = true
+config.audible_bell = "Disabled"
+config.scrollback_lines = 200000  -- generous like common Kitty configs
+
+-- On macOS, Option-as-Alt behavior close to terminal defaults
+-- (You can tweak these if you rely on AltGr-like compose)
+config.send_composed_key_when_left_alt_is_pressed = true
+config.send_composed_key_when_right_alt_is_pressed = true  -- mirrors Kitty’s “option as alt” feel
+-- Enable Kitty keyboard protocol so nvim can see richer key combos
+config.enable_kitty_keyboard = true
+
+-- Key feel: make ⌘ act like Ctrl for the combos you asked about.
+-- This works in local and remote sessions (no fragile process detection).
+if wezterm.target_triple:find("darwin") then
+  config.keys = config.keys or {}
+  table.insert(config.keys, { key = "d", mods = "CMD", action = act.SendKey({ key = "d", mods = "CTRL" }) })
+  table.insert(config.keys, { key = "u", mods = "CMD", action = act.SendKey({ key = "u", mods = "CTRL" }) })
+  -- Tip: you can mirror more Kitty habits here, e.g.
+  -- table.insert(config.keys, { key = "LeftArrow",  mods = "CMD", action = act.SendKey({ key="a", mods="CTRL" }) }) -- ⌘← => Ctrl-A
+  -- table.insert(config.keys, { key = "RightArrow", mods = "CMD", action = act.SendKey({ key="e", mods="CTRL" }) }) -- ⌘→ => Ctrl-E
+end
+
+-- Color scheme: keep system/WezTerm default; align to Kitty later if you want:
+-- config.color_scheme = "Gruvbox Dark (Hard)"  -- or whatever you use in Kitty
+
+return config

--- a/run_once_55-install-wezterm.ps1.tmpl
+++ b/run_once_55-install-wezterm.ps1.tmpl
@@ -1,0 +1,19 @@
+# Idempotent winget install on first apply
+$ErrorActionPreference = "Stop"
+
+if (Get-Command wezterm -ErrorAction SilentlyContinue) {
+  Write-Host "wezterm already installed: $(wezterm -V 2>$null)"
+  exit 0
+}
+
+if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
+  Write-Host "winget not found. Install App Installer from Microsoft Store, then re-run chezmoi."
+  exit 0
+}
+
+$pkg = winget list --id wez.wezterm -e
+if ($LASTEXITCODE -eq 0 -and $pkg) {
+  Write-Host "wezterm present via winget."
+} else {
+  winget install --id wez.wezterm -e --accept-package-agreements --accept-source-agreements
+}

--- a/run_onchange_55-install-wezterm.sh.tmpl
+++ b/run_onchange_55-install-wezterm.sh.tmpl
@@ -1,0 +1,103 @@
+{{- /* chezmoi template: run on change; safe on repeated runs */ -}}
+#!/usr/bin/env bash
+set -euo pipefail
+
+OS="{{ .chezmoi.os }}"
+
+has() { command -v "$1" >/dev/null 2>&1; }
+
+already() {
+  echo "wezterm already installed: $($1 2>/dev/null || echo 'detected')"
+}
+
+if has wezterm; then
+  already "wezterm -V"
+  exit 0
+fi
+
+case "$OS" in
+  darwin)
+    if has brew; then
+      if brew list --cask wezterm >/dev/null 2>&1; then
+        already "brew list --cask wezterm"
+      else
+        echo "Installing WezTerm with Homebrew Cask…"
+        brew install --cask wezterm   # official cask name
+      fi
+    else
+      echo "Homebrew not found; skipping WezTerm install on macOS."
+    fi
+    ;;
+
+  linux)
+    if has apt-get; then
+      # Use official APT repo if needed (adds once), then install
+      if ! dpkg -s wezterm >/dev/null 2>&1; then
+        if ! [ -f /etc/apt/sources.list.d/wezterm.list ]; then
+          echo "Configuring official WezTerm APT repo…"
+          sudo mkdir -p /usr/share/keyrings
+          curl -fsSL https://apt.fury.io/wez/gpg.key \
+            | sudo gpg --yes --dearmor -o /usr/share/keyrings/wezterm-fury.gpg
+          echo 'deb [signed-by=/usr/share/keyrings/wezterm-fury.gpg] https://apt.fury.io/wez/ * *' \
+            | sudo tee /etc/apt/sources.list.d/wezterm.list >/dev/null
+          sudo chmod 644 /usr/share/keyrings/wezterm-fury.gpg
+        fi
+        echo "Installing WezTerm via apt…"
+        sudo apt-get update -qq
+        sudo apt-get install -y wezterm || {
+          echo "APT package not available; trying Flatpak if present…"
+          if has flatpak; then
+            flatpak install -y flathub org.wezfurlong.wezterm || true
+          fi
+        }
+      else
+        already "dpkg -s wezterm"
+      fi
+
+    elif has dnf; then
+      # Fedora/RHEL; prefer official Copr if base repo lacks it
+      if rpm -q wezterm >/dev/null 2>&1; then
+        already "rpm -q wezterm"
+      else
+        echo "Installing WezTerm on rpm-based distro…"
+        sudo dnf -y install wezterm || {
+          sudo dnf -y copr enable wezfurlong/wezterm-nightly || true
+          sudo dnf -y install wezterm || sudo dnf -y install wezterm-nightly || true
+        }
+      fi
+
+    elif has pacman; then
+      if pacman -Qi wezterm >/dev/null 2>&1; then
+        already "pacman -Qi wezterm"
+      else
+        echo "Installing WezTerm via pacman…"
+        sudo pacman -S --noconfirm wezterm || {
+          echo "Package not found; consider AUR or Flatpak (org.wezfurlong.wezterm)."
+        }
+      fi
+
+    else
+      echo "Unknown Linux distro; attempting Flatpak if available…"
+      if has flatpak; then
+        flatpak install -y flathub org.wezfurlong.wezterm || true
+      fi
+    fi
+    ;;
+
+  windows)
+    # If chezmoi runs in MSYS/Git-Bash, call PowerShell/winget for install.
+    if has powershell.exe; then
+      echo "Ensuring WezTerm via winget…"
+      powershell.exe -NoProfile -ExecutionPolicy Bypass -Command \
+        "if (-not (winget list --id wez.wezterm -e | Select-String wezterm)) { winget install --id wez.wezterm -e --accept-package-agreements --accept-source-agreements }"
+    else
+      echo "powershell.exe not found; skipping Windows install."
+    fi
+    ;;
+
+  *)
+    echo "Unsupported OS: $OS"
+    ;;
+esac
+
+exit 0


### PR DESCRIPTION
## Summary
- install WezTerm via chezmoi scripts across macOS, Linux, and Windows
- provide PowerShell helper for winget-based installs
- add WezTerm config mirroring Kitty font and key bindings

## Testing
- `bash -n /tmp/wezterm_install.sh`
- `shellcheck /tmp/wezterm_install.sh`
- `luac5.4 -p /tmp/wezterm.lua`
- `sudo apt-get install -y powershell` *(fails: Unable to locate package powershell)*

------
https://chatgpt.com/codex/tasks/task_e_689f525beb808324bc90681ed4d118a0