### PR TITLE
feat: disable mac charging chime

### DIFF
--- a/run_once_10-disable-charge-chime-darwin.sh.tmpl
+++ b/run_once_10-disable-charge-chime-darwin.sh.tmpl
@@ -1,0 +1,13 @@
+{{- if eq .chezmoi.os "darwin" -}}
+#!/usr/bin/env bash
+# Disable Mac's charging chime (per-user).
+# Runs once via chezmoi. Safe to re-run: it's idempotent.
+
+set -euo pipefail
+
+/usr/bin/defaults write com.apple.PowerChime ChimeOnNoHardware -bool true
+
+# Apply immediately (PowerChime is the tiny agent that plays the sound)
+# /usr/bin/killall exits non-zero if process not found; ignore that.
+/usr/bin/killall PowerChime >/dev/null 2>&1 || true
+{{- end -}}


### PR DESCRIPTION
## Summary
- disable charging chime on macOS via `run_once` script

## Testing
- `bash -n <(grep -v '{{' run_once_10-disable-charge-chime-darwin.sh.tmpl)`
- `grep -v '{{' run_once_10-disable-charge-chime-darwin.sh.tmpl | shellcheck -`


------
https://chatgpt.com/codex/tasks/task_e_68a06cef82a483248fdfcba4167e4046