### PR TITLE
Set Neovim as default editor with run-once scripts

### DIFF
--- a/.chezmoiscripts/run_once_20-source-editor-into-rc.sh.tmpl
+++ b/.chezmoiscripts/run_once_20-source-editor-into-rc.sh.tmpl
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+insert_once () {
+  local file="$1"
+  local line="$2"
+  mkdir -p "$(dirname "$file")"
+  touch "$file"
+  # Add the line only if it's not already there (exact match).
+  grep -Fqx "$line" "$file" || printf '\n%s\n' "$line" >> "$file"
+}
+
+LINE='[ -f "{{ .chezmoi.homeDir }}/.config/shell/00-editor.sh" ] && . "{{ .chezmoi.homeDir }}/.config/shell/00-editor.sh"'
+
+insert_once "{{ .chezmoi.homeDir }}/.bashrc"  "$LINE"
+insert_once "{{ .chezmoi.homeDir }}/.zshrc"   "$LINE"
+# Optional but handy on macOS login shells:
+insert_once "{{ .chezmoi.homeDir }}/.zprofile" "$LINE"

--- a/.chezmoiscripts/run_once_30-git-editor.sh.tmpl
+++ b/.chezmoiscripts/run_once_30-git-editor.sh.tmpl
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+git config --global core.editor "nvim"
+git config --global sequence.editor "nvim"

--- a/dot_config/shell/00-editor.sh
+++ b/dot_config/shell/00-editor.sh
@@ -1,0 +1,7 @@
+# Managed by chezmoi — editor settings
+export VISUAL="nvim"
+export EDITOR="$VISUAL"
+export GIT_EDITOR="$VISUAL"
+export SEQUENCE_EDITOR="$VISUAL"
+# GN looks at GN_EDITOR, then VISUAL, then EDITOR
+export GN_EDITOR="$VISUAL"


### PR DESCRIPTION
## Summary
- Add shared shell snippet to export editor-related variables
- Add run_once scripts to source snippet into rc files and configure git editor

## Testing
- `chezmoi doctor`


------
https://chatgpt.com/codex/tasks/task_e_68a08e062ea483249c9d07e28fc7d583