### PR TITLE
Add JetBrains Mono variable fonts via chezmoi external

### DIFF
--- a/.chezmoiexternal.toml.tmpl
+++ b/.chezmoiexternal.toml.tmpl
@@ -1,0 +1,30 @@
+# .chezmoiexternal.toml.tmpl
+# Download the latest JetBrains Mono release ZIP and extract only the Variable TTFs.
+{{- $asset := gitHubLatestReleaseAssetURL "JetBrains/JetBrainsMono" "JetBrainsMono-*.zip" -}}
+
+{{ if eq .chezmoi.os "linux" }}
+[".local/share/fonts/JetBrainsMono-Variable"]
+type = "archive"
+url = {{ $asset | quote }}
+include = ["*/fonts/variable/*.ttf"]
+stripComponents = 3
+refreshPeriod = "672h"
+{{ end }}
+
+{{ if eq .chezmoi.os "darwin" }}
+["Library/Fonts/JetBrainsMono-Variable"]
+type = "archive"
+url = {{ $asset | quote }}
+include = ["*/fonts/variable/*.ttf"]
+stripComponents = 3
+refreshPeriod = "672h"
+{{ end }}
+
+{{ if eq .chezmoi.os "windows" }}
+["AppData/Local/Microsoft/Windows/Fonts/JetBrainsMono-Variable"]
+type = "archive"
+url = {{ $asset | quote }}
+include = ["*/fonts/variable/*.ttf"]
+stripComponents = 3
+refreshPeriod = "672h"
+{{ end }}


### PR DESCRIPTION
## Summary
- add `.chezmoiexternal.toml.tmpl` to download JetBrains Mono variable TTFs for Linux, macOS, and Windows

## Testing
- `chezmoi --version`
- `chezmoi --source $PWD --destination "$tmpdir2" apply -R --include=externals`


------
https://chatgpt.com/codex/tasks/task_e_68a24b1f1670832497f3c3ad011b7eb8