### PR TITLE
feat: open Explorer files with Enter on macOS

### DIFF
--- a/.chezmoitemplates/vscode-keybindings.json
+++ b/.chezmoitemplates/vscode-keybindings.json
@@ -28,7 +28,13 @@
   { "key": "shift+cmd+left",  "command": "-cursorHomeSelect", "when": "editorTextFocus" },
   { "key": "shift+cmd+right", "command": "-cursorEndSelect",  "when": "editorTextFocus" },
   { "key": "shift+cmd+left",  "command": "cursorWordStartLeftSelect", "when": "editorTextFocus" },
-  { "key": "shift+cmd+right", "command": "cursorWordEndRightSelect",  "when": "editorTextFocus" }
+  { "key": "shift+cmd+right", "command": "cursorWordEndRightSelect",  "when": "editorTextFocus" },
+
+  // ----- Open files with Enter in the Explorer -----
+  { "key": "enter",      "command": "-renameFile",         "when": "explorerViewletVisible && filesExplorerFocus && !inputFocus" },
+  { "key": "enter",      "command": "list.select",         "when": "explorerViewletVisible && filesExplorerFocus && !inputFocus" },
+  { "key": "cmd+enter",  "command": "renameFile",          "when": "explorerViewletVisible && filesExplorerFocus && !inputFocus" },
+  { "key": "ctrl+enter", "command": "explorer.openToSide", "when": "explorerViewletVisible && filesExplorerFocus && !inputFocus" },
 {{- end }}
 
   // Page Down - workround to make cursor movement match Nvim


### PR DESCRIPTION
## Summary
- remap Enter in VS Code Explorer on macOS to open files instead of rename
- add Cmd+Enter for rename and Ctrl+Enter for open to side

## Testing
- `npm test` *(fails: Could not read package.json)*
- `make test` *(fails: No rule to make target 'test')*


------
https://chatgpt.com/codex/tasks/task_e_68a24ad48a088324863f27a7892fbf24