### PR TITLE
fix(mac): remove comment from VS Code keybindings template

### DIFF
--- a/.chezmoitemplates/vscode-keybindings.json
+++ b/.chezmoitemplates/vscode-keybindings.json
@@ -30,7 +30,6 @@
   { "key": "shift+cmd+left",  "command": "cursorWordStartLeftSelect", "when": "editorTextFocus" },
   { "key": "shift+cmd+right", "command": "cursorWordEndRightSelect",  "when": "editorTextFocus" },
 
-  // ----- Open files with Enter in the Explorer -----
   { "key": "enter",      "command": "-renameFile",         "when": "explorerViewletVisible && filesExplorerFocus && !inputFocus" },
   { "key": "enter",      "command": "list.select",         "when": "explorerViewletVisible && filesExplorerFocus && !inputFocus" },
   { "key": "cmd+enter",  "command": "renameFile",          "when": "explorerViewletVisible && filesExplorerFocus && !inputFocus" },


### PR DESCRIPTION
## Summary
- remove inline comment so VS Code keybindings template parses as JSON on macOS

## Testing
- `chezmoi execute-template -S . -f dot_config/Code/User/keybindings.json.tmpl >/dev/null`
- `chezmoi apply -n -v -k -S . >/tmp/apply.log`


------
https://chatgpt.com/codex/tasks/task_e_68a277a151c88324981a51254ca82c51