### PR TITLE
Add Lazygit install scripts and theme configuration

### DIFF
--- a/dot_config/lazygit/config.yml.tmpl
+++ b/dot_config/lazygit/config.yml.tmpl
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/jesseduffield/lazygit/master/schema/config.json
+
+gui:
+  # Use Nerd Font v3 icons (your repo already installs JetBrainsMono Nerd Font)
+  # Set to "2" if you still use Nerd Font v2.
+  nerdFontsVersion: "3"
+  showFileIcons: true
+
+  # Keep the theme dark. The actual colors will be supplied by LazyVim when you
+  # open Lazygit from Neovim (see §3).
+  theme:
+    lightTheme: false
+

--- a/dot_config/nvim/lua/plugins/colorscheme.lua
+++ b/dot_config/nvim/lua/plugins/colorscheme.lua
@@ -1,0 +1,14 @@
+return {
+  -- Install & configure tokyonight and pin style to "moon"
+  {
+    "folke/tokyonight.nvim",
+    lazy = true,
+    opts = { style = "moon" },
+  },
+  -- Tell LazyVim to load tokyonight
+  {
+    "LazyVim/LazyVim",
+    opts = { colorscheme = "tokyonight" },
+  },
+}
+

--- a/run_once_40-install-lazygit.ps1.tmpl
+++ b/run_once_40-install-lazygit.ps1.tmpl
@@ -1,0 +1,18 @@
+{{ if eq .chezmoi.os "windows" -}}
+# Requires: PowerShell
+# Installs lazygit via winget (or scoop fallback)
+$have = Get-Command lazygit -ErrorAction SilentlyContinue
+if ($have) { exit 0 }
+
+if (Get-Command winget -ErrorAction SilentlyContinue) {
+  winget install -e --id JesseDuffield.lazygit
+}
+elseif (Get-Command scoop -ErrorAction SilentlyContinue) {
+  scoop bucket add extras | Out-Null
+  scoop install lazygit
+}
+else {
+  Write-Host "winget/scoop not found. Install lazygit manually."
+  exit 1
+}
+{{ end -}}

--- a/run_once_40-install-lazygit.sh.tmpl
+++ b/run_once_40-install-lazygit.sh.tmpl
@@ -1,0 +1,26 @@
+{{ if ne .chezmoi.os "windows" -}}
+#!/usr/bin/env bash
+set -euo pipefail
+
+if command -v lazygit >/dev/null 2>&1; then
+  exit 0
+fi
+
+if command -v brew >/dev/null 2>&1; then
+  brew install lazygit
+elif command -v apt-get >/dev/null 2>&1; then
+  sudo apt-get update -y
+  sudo apt-get install -y lazygit
+elif command -v dnf >/dev/null 2>&1; then
+  # Fedora/RHEL/CentOS (uses COPR if needed)
+  sudo dnf install -y lazygit || { sudo dnf copr enable -y atim/lazygit; sudo dnf install -y lazygit; }
+elif command -v pacman >/dev/null 2>&1; then
+  sudo pacman -Sy --noconfirm lazygit
+elif command -v zypper >/dev/null 2>&1; then
+  sudo zypper refresh
+  sudo zypper install -y lazygit
+else
+  echo "No supported package manager found. Install lazygit manually."
+  exit 1
+fi
+{{ end -}}


### PR DESCRIPTION
## Summary
- install Lazygit via platform-specific chezmoi run_once scripts
- manage Lazygit config with Nerd Font icons
- set LazyVim colorscheme to Tokyonight moon

## Testing
- `chezmoi -S . -D /tmp/chezmoi-dest apply --dry-run --verbose | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68a30ca49b948324921df9ed37e0ce6b