### PR TITLE
Integrate LazyGit VS Code extension

### DIFF
--- a/.chezmoitemplates/vscode-extensions.json
+++ b/.chezmoitemplates/vscode-extensions.json
@@ -1,5 +1,6 @@
 {
   "recommendations": [
+    "TomPollak.lazygit-vscode",
     "vscodevim.vim",
     "qufiwefefwoyn.kanagawa",
     "formulahendry.auto-close-tag",

--- a/.chezmoitemplates/vscode-keybindings.json
+++ b/.chezmoitemplates/vscode-keybindings.json
@@ -4,6 +4,18 @@
   // Disable line move shortcuts
   { "key": "alt+down", "command": "-editor.action.moveLinesDownAction" },
   { "key": "alt+up", "command": "-editor.action.moveLinesUpAction" },
+
+  // Make Esc go to LazyGit when it's focused
+  {
+    "key": "escape",
+    "command": "-extension.vim_escape",
+    "when": "editorTextFocus && vim.active && !inDebugRepl"
+  },
+  {
+    "key": "escape",
+    "command": "extension.vim_escape",
+    "when": "editorTextFocus && vim.active && !inDebugRepl && !lazygitFocus"
+  },
 {{- if eq .chezmoi.os "darwin" }}
   // ----- Word navigation on ⌘ + ← / → -----
   // Remove defaults (line start/end) that would conflict:

--- a/.chezmoitemplates/vscode-settings.json
+++ b/.chezmoitemplates/vscode-settings.json
@@ -29,6 +29,12 @@
   "workbench.quickOpen.centered": true,
   "window.commandCenter": false,
   "search.location": "panel",
+  "lazygit-vscode.autoMaximizeWindow": true,
+  "lazygit-vscode.panels": {
+    "sidebar": "hideRestore",
+    "panel": "hide",
+    "secondarySidebar": "keep"
+  },
   // Disable AI code suggestions and built-in tag closing
   "editor.inlineSuggest.enabled": false,
   "github.copilot.enable": {
@@ -1003,13 +1009,7 @@
         "g"
       ],
       "commands": [
-        "workbench.action.terminal.toggleTerminal",
-        {
-          "command": "workbench.action.terminal.sendSequence",
-          "args": {
-            "text": "lazygit\u000D"
-          }
-        }
+        "lazygit-vscode.toggle"
       ]
     },
     {

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,6 @@
 {
   "recommendations": [
+    "TomPollak.lazygit-vscode",
     "vscodevim.vim",
     "qufiwefefwoyn.kanagawa",
     "formulahendry.auto-close-tag",

--- a/AppData/Roaming/Code/User/extensions.json.tmpl
+++ b/AppData/Roaming/Code/User/extensions.json.tmpl
@@ -1,0 +1,1 @@
+{{- template "vscode-extensions.json" . -}}

--- a/Library/Application Support/Code/User/extensions.json.tmpl
+++ b/Library/Application Support/Code/User/extensions.json.tmpl
@@ -1,0 +1,1 @@
+{{- template "vscode-extensions.json" . -}}

--- a/dot_chezmoiignore
+++ b/dot_chezmoiignore
@@ -1,16 +1,19 @@
 {{ if ne .chezmoi.os "darwin" }}
 Library/Application Support/Code/User/settings.json
 Library/Application Support/Code/User/keybindings.json
+Library/Application Support/Code/User/extensions.json
 {{ end }}
 
 {{ if ne .chezmoi.os "linux" }}
 .config/Code/User/settings.json
 .config/Code/User/keybindings.json
+.config/Code/User/extensions.json
 {{ end }}
 
 {{ if ne .chezmoi.os "windows" }}
 AppData/Roaming/Code/User/settings.json
 AppData/Roaming/Code/User/keybindings.json
+AppData/Roaming/Code/User/extensions.json
 {{ end }}
 
 .vscode

--- a/dot_config/Code/User/extensions.json.tmpl
+++ b/dot_config/Code/User/extensions.json.tmpl
@@ -1,0 +1,1 @@
+{{- template "vscode-extensions.json" . -}}

--- a/dot_config/lazygit/config.yml.tmpl
+++ b/dot_config/lazygit/config.yml.tmpl
@@ -11,3 +11,8 @@ gui:
   theme:
     lightTheme: false
 
+os:
+  editPreset: "vscode"
+
+promptToReturnFromSubprocess: false
+


### PR DESCRIPTION
## Summary
- recommend LazyGit VSCode extension alongside existing suggestions
- open LazyGit in a maximized editor tab and map `<leader> g g` to toggle it
- ensure Escape reaches LazyGit and configure it to edit with VS Code

## Testing
- `chezmoi apply --source $(pwd) --destination /tmp/chezmoi-home --dry-run --verbose`

------
https://chatgpt.com/codex/tasks/task_e_68a37abbd8b08324aa815d302ee7cd8c