### PR TITLE
feat: add chat input page navigation keybindings

### DIFF
--- a/.chezmoitemplates/vscode-keybindings.json
+++ b/.chezmoitemplates/vscode-keybindings.json
@@ -594,6 +594,80 @@
     "when": "auxiliaryBarFocus && listFocus && !inputFocus"
   },
 
+  // Page Copilot Chat history from input
+  {
+    "key": "cmd+d",
+    "command": "runCommands",
+    "when": "inChatInput",
+    "args": {
+      "commands": [
+        "workbench.action.chat.focus",
+        "list.focusPageDown",
+        "workbench.action.chat.focusInput"
+      ]
+    }
+  },
+  {
+    "key": "cmd+u",
+    "command": "runCommands",
+    "when": "inChatInput",
+    "args": {
+      "commands": [
+        "workbench.action.chat.focus",
+        "list.focusPageUp",
+        "workbench.action.chat.focusInput"
+      ]
+    }
+  },
+  {
+    "key": "ctrl+d",
+    "command": "runCommands",
+    "when": "inChatInput",
+    "args": {
+      "commands": [
+        "workbench.action.chat.focus",
+        "list.focusPageDown",
+        "workbench.action.chat.focusInput"
+      ]
+    }
+  },
+  {
+    "key": "ctrl+u",
+    "command": "runCommands",
+    "when": "inChatInput",
+    "args": {
+      "commands": [
+        "workbench.action.chat.focus",
+        "list.focusPageUp",
+        "workbench.action.chat.focusInput"
+      ]
+    }
+  },
+  {
+    "key": "pageDown",
+    "command": "runCommands",
+    "when": "inChatInput",
+    "args": {
+      "commands": [
+        "workbench.action.chat.focus",
+        "list.focusPageDown",
+        "workbench.action.chat.focusInput"
+      ]
+    }
+  },
+  {
+    "key": "pageUp",
+    "command": "runCommands",
+    "when": "inChatInput",
+    "args": {
+      "commands": [
+        "workbench.action.chat.focus",
+        "list.focusPageUp",
+        "workbench.action.chat.focusInput"
+      ]
+    }
+  },
+
   // Right (Secondary) Side Bar — single ⌘ stroke
   { "key": "cmd+;", "command": "workbench.action.focusAuxiliaryBar",   "when": "!auxiliaryBarFocus" },
   { "key": "cmd+;", "command": "workbench.action.toggleAuxiliaryBar",  "when": "auxiliaryBarFocus" },


### PR DESCRIPTION
## Summary
- allow paging Copilot chat history while typing via `cmd/ctrl+d`, `cmd/ctrl+u`, and Page Up/Down

## Testing
- `chezmoi doctor` *(fails: open ~/.local/share/chezmoi: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a3946909a083248ba3d849e397f041