### PR TITLE
Forward Esc to LazyGit webview in VS Code

### DIFF
--- a/.chezmoitemplates/vscode-keybindings.json
+++ b/.chezmoitemplates/vscode-keybindings.json
@@ -8,6 +8,17 @@
   // Make Esc go to LazyGit when it's focused
   {
     "key": "escape",
+    "command": "type",
+    "args": { "text": "\u001b" },
+    "when": "lazygitFocus"
+  },
+  {
+    "key": "escape",
+    "command": "-extension.vim_escape",
+    "when": "lazygitFocus && vim.active"
+  },
+  {
+    "key": "escape",
     "command": "-extension.vim_escape",
     "when": "editorTextFocus && vim.active && !inDebugRepl"
   },


### PR DESCRIPTION
## Summary
- send raw Escape key to LazyGit when its VS Code webview is focused
- disable VSCodeVim's Esc mapping when LazyGit is active

## Testing
- `chezmoi doctor` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a39b104638832489c9b43dc90e7033