### PR TITLE
feat: theme lazygit and VS Code terminal

### DIFF
--- a/.chezmoitemplates/vscode-settings.json
+++ b/.chezmoitemplates/vscode-settings.json
@@ -14,6 +14,7 @@
   "terminal.integrated.letterSpacing": 1.0,
   "terminal.integrated.fontWeight": "normal",
   "terminal.integrated.fontFamily": "JetBrainsMono Nerd Font",
+  "terminal.integrated.minimumContrastRatio": 1,
   "editor.lineNumbers": "relative",
   "editor.renderLineHighlight": "all",
   "workbench.colorTheme": "Tokyo Night Storm",

--- a/dot_config/lazygit/config.yml.tmpl
+++ b/dot_config/lazygit/config.yml.tmpl
@@ -5,11 +5,19 @@ gui:
   # Set to "2" if you still use Nerd Font v2.
   nerdFontsVersion: "3"
   showFileIcons: true
-
-  # Keep the theme dark. The actual colors will be supplied by LazyVim when you
-  # open Lazygit from Neovim (see §3).
   theme:
     lightTheme: false
+    # Tokyo Night Moon colors
+    activeBorderColor:
+      - "#82aaff"
+    inactiveBorderColor:
+      - "#444a73"
+    selectedLineBgColor:
+      - "#2d3f76"
+    optionsTextColor:
+      - "#ffc777"
+    defaultFgColor:
+      - "#c8d3f5"
 
 os:
   editPreset: "vscode"


### PR DESCRIPTION
## Summary
- configure LazyGit with Tokyo Night Moon palette for better selection visibility
- ensure VS Code terminal uses exact theme colors by disabling contrast adjustment

## Testing
- `node -e "JSON.parse(require('fs').readFileSync('.chezmoitemplates/vscode-settings.json', 'utf8'))"` *(fails: SyntaxError: Expected property name or '}' in JSON at position 4)*
- `python - <<'PY'
import yaml, sys
print(yaml.safe_load(open('dot_config/lazygit/config.yml.tmpl')))
PY` *(fails: ModuleNotFoundError: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_68a4170e4d088324a49aa7ae543c8ce7