### PR TITLE
feat: configure FindItFaster with Tokyo Night

### DIFF
--- a/.chezmoitemplates/vscode-extensions.json
+++ b/.chezmoitemplates/vscode-extensions.json
@@ -4,7 +4,9 @@
     "vscodevim.vim",
     "qufiwefefwoyn.kanagawa",
     "formulahendry.auto-close-tag",
-    "RodrigoScola.vscode-textobjects"
+    "RodrigoScola.vscode-textobjects",
+    "TomRijndorp.find-it-faster",
+    "PatrickNasralla.tokyo-night-moon"
   ],
   "unwantedRecommendations": []
 }

--- a/.chezmoitemplates/vscode-settings.json
+++ b/.chezmoitemplates/vscode-settings.json
@@ -16,8 +16,8 @@
   "terminal.integrated.fontFamily": "JetBrainsMono Nerd Font",
   "editor.lineNumbers": "relative",
   "editor.renderLineHighlight": "all",
-  "workbench.colorTheme": "Tokyo Night Storm",
-  "workbench.preferredDarkColorTheme": "Tokyo Night Storm",
+  "workbench.colorTheme": "Tokyo Night Moon",
+  "workbench.preferredDarkColorTheme": "Tokyo Night Moon",
   "workbench.colorCustomizations": {
     "editorCursor.foreground": "#D0CCB2",
     "editorCursor.background": "#000000",
@@ -35,6 +35,10 @@
     "panel": "hide",
     "secondarySidebar": "keep"
   },
+  // FindItFaster and terminal setup
+  "find-it-faster.general.useTerminalInEditor": true,
+  "find-it-faster.general.killTerminalAfterUse": true,
+  "terminal.integrated.allowChords": false,
   // Disable AI code suggestions and built-in tag closing
   "editor.inlineSuggest.enabled": false,
   "github.copilot.enable": {
@@ -71,7 +75,7 @@
   "vim.useSystemClipboard": true,
   "vim.useCtrlKeys": true,
   "vim.surround": true,
-  "vim.leader": "<space>",
+  "vim.leader": " ",
   "vim.hlsearch": true,
   "vim.highlightedyank.enable": true,
   "vim.highlightedyank.color": "rgba(255, 223, 93, 0.3)", // warm gold, soft opacity
@@ -563,7 +567,27 @@
         "f"
       ],
       "commands": [
-        "workbench.action.quickOpen"
+        "find-it-faster.findFiles"
+      ]
+    },
+    {
+      "before": [
+        "leader",
+        "f",
+        "g"
+      ],
+      "commands": [
+        "find-it-faster.findWithinFiles"
+      ]
+    },
+    {
+      "before": [
+        "leader",
+        "f",
+        "o"
+      ],
+      "commands": [
+        "find-it-faster.resumeSearch"
       ]
     },
     {

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,7 +4,9 @@
     "vscodevim.vim",
     "qufiwefefwoyn.kanagawa",
     "formulahendry.auto-close-tag",
-    "RodrigoScola.vscode-textobjects"
+    "RodrigoScola.vscode-textobjects",
+    "TomRijndorp.find-it-faster",
+    "PatrickNasralla.tokyo-night-moon"
   ],
   "unwantedRecommendations": []
 }

--- a/dot_zshrc
+++ b/dot_zshrc
@@ -1,3 +1,19 @@
+# shellcheck shell=bash
 export PATH="$PATH:/Users/freedebreuil/tools/depot_tools"
 
+# shellcheck source=/Users/freedebreuil/.config/shell/00-editor.sh
+# shellcheck disable=SC1091
 [ -f "/Users/freedebreuil/.config/shell/00-editor.sh" ] && . "/Users/freedebreuil/.config/shell/00-editor.sh"
+
+# Tokyo Night Moon colors for FindItFaster
+export BAT_THEME="tokyonight_moon"
+
+if [[ $FIND_IT_FASTER_ACTIVE -eq 1 ]]; then
+    # Tokyo Night Moon color palette for fzf (requires Nerd Font for icons)
+    export FZF_DEFAULT_OPTS="\
+      --color=bg:#1a1b26,bg+:#24283b,fg:#c0caf5,fg+:#a9b1d6,\
+             hl:#7aa2f7,hl+:#7dcfff,info:#0db9d7,prompt:#bb9af7,\
+             pointer:#f7768e,marker:#ff9e64 \
+      --prompt=' ' --pointer=' ' \
+      --bind=ctrl-n:down,ctrl-p:up"
+fi


### PR DESCRIPTION
## Summary
- apply Tokyo Night Moon theme and FindItFaster terminal settings
- add leader key mappings for FindItFaster commands
- recommend FindItFaster and Tokyo Night Moon VS Code extensions
- configure FZF and bat colors for Tokyo Night Moon

## Testing
- `shellcheck dot_zshrc`
- `jq . .vscode/extensions.json`


------
https://chatgpt.com/codex/tasks/task_e_68a416d5877c83249ba56a35e58f95de