### PR TITLE
Add reusable FZF tools and VS Code integration

### DIFF
--- a/.chezmoitemplates/vscode-keybindings.json
+++ b/.chezmoitemplates/vscode-keybindings.json
@@ -790,6 +790,29 @@
   { "key": "cmd+3",  "command": "workbench.action.focusThirdEditorGroup" },
   { "key": "ctrl+1", "command": "workbench.action.focusFirstEditorGroup" },
   { "key": "ctrl+2", "command": "workbench.action.focusSecondEditorGroup" },
-  { "key": "ctrl+3", "command": "workbench.action.focusThirdEditorGroup" }
+  { "key": "ctrl+3", "command": "workbench.action.focusThirdEditorGroup" },
+  // FZF search tools
+  {
+    "key": "ctrl+alt+f",
+    "command": "workbench.action.terminal.newWithProfile",
+    "args": { "profileName": "FZF Files", "location": "panel" }
+  },
+  {
+    "key": "ctrl+alt+shift+f",
+    "command": "workbench.action.terminal.newWithProfile",
+    "args": { "profileName": "FZF Text", "location": "panel" }
+  },
+  {
+    "key": "ctrl+alt+f",
+    "command": "workbench.action.terminal.sendSequence",
+    "args": { "text": "vf\u000D" },
+    "when": "terminalIsOpen"
+  },
+  {
+    "key": "ctrl+alt+shift+f",
+    "command": "workbench.action.terminal.sendSequence",
+    "args": { "text": "vt\u000D" },
+    "when": "terminalIsOpen"
+  }
 ]
 

--- a/.chezmoitemplates/vscode-settings.json
+++ b/.chezmoitemplates/vscode-settings.json
@@ -15,6 +15,26 @@
   "terminal.integrated.fontWeight": "normal",
   "terminal.integrated.fontFamily": "JetBrainsMono Nerd Font",
   "terminal.integrated.minimumContrastRatio": 1,
+  "terminal.integrated.profiles.osx": {
+    "FZF Files": {
+      "path": "/bin/zsh",
+      "args": ["-lc", "~/.local/bin/vf || true; exit 0"],
+      "icon": "search",
+      "overrideName": true
+    },
+    "FZF Text": {
+      "path": "/bin/zsh",
+      "args": ["-lc", "~/.local/bin/vt || true; exit 0"],
+      "icon": "search",
+      "overrideName": true
+    }
+  },
+
+  // You already have these, good for overall speed
+  "terminal.integrated.enablePersistentSessions": true,
+  "terminal.integrated.persistentSessionReviveProcess": "onExit",
+  "terminal.integrated.persistentSessionScrollback": 10000,
+  "terminal.integrated.sendKeybindingsToShell": true,
   "editor.lineNumbers": "relative",
   "editor.renderLineHighlight": "all",
   "workbench.colorTheme": "Tokyo Night Storm",

--- a/dot_config/fzf/tokyonight.zsh
+++ b/dot_config/fzf/tokyonight.zsh
@@ -1,0 +1,14 @@
+# FZF look & feel similar to LazyVim's dropdown
+export FZF_DEFAULT_OPTS="$FZF_DEFAULT_OPTS
+  --layout=reverse
+  --border=rounded
+  --height=60%
+  --info=inline
+  --margin=1,3
+  --no-separator
+  --pointer='❯'
+  --marker='✓'
+  --ansi
+  --bind=ctrl-j:down,ctrl-k:up,alt-j:down,alt-k:up,ctrl-u:half-page-up,ctrl-d:half-page-down,alt-p:toggle-preview
+  --color=fg:#c0caf5,bg:#1a1b26,hl:#7aa2f7,fg+:#c0caf5,bg+:#24283b,hl+:#7aa2f7,info:#7aa2f7,prompt:#7dcfff,pointer:#ff9e64,marker:#9ece6a,spinner:#bb9af7,header:#565f89,border:#3b4261
+"

--- a/dot_local/bin/executable_vf
+++ b/dot_local/bin/executable_vf
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Use Git index when available (fast), else fd -> rg -> find
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  SRC_CMD=(git -c core.quotepath=false ls-files -co --exclude-standard)
+elif command -v fd >/dev/null 2>&1; then
+  SRC_CMD=(fd --type f --hidden --follow --exclude .git)
+elif command -v rg >/dev/null 2>&1; then
+  SRC_CMD=(rg --files --hidden --follow -g '!.git')
+else
+  SRC_CMD=(find . -type f)
+fi
+
+# Preview (bat if present, else head)
+PREVIEW='bat --style=numbers --color=always -- {} 2>/dev/null || head -n 200 -- {}'
+
+# Run fzf (multi-select supported)
+# We do NOT use arithmetic or history expansion; this runs in bash
+SEL="$("${SRC_CMD[@]}" | fzf --prompt='Files   ' \
+  --preview "$PREVIEW" --preview-window=right,60%,border,hidden \
+  --multi || true)"
+
+# Open the selected files in VS Code (preferred)
+if [[ -n "${SEL:-}" ]]; then
+  mapfile -t ITEMS < <(printf '%s\n' "$SEL")
+  if command -v code >/dev/null 2>&1; then
+    code -r -- "${ITEMS[@]}"
+  else
+    # Fallback to $VISUAL / $EDITOR if code isn't installed
+    "${VISUAL:-${EDITOR:-vi}}" "${ITEMS[@]}"
+  fi
+fi
+exit 0

--- a/dot_local/bin/executable_vt
+++ b/dot_local/bin/executable_vt
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Initial query can be passed as arguments, e.g. vt "todo:"
+QUERY="${*:-}"
+
+# ripgrep base (hidden files, respect .gitignore; exclude .git)
+RG_PREFIX=(rg --column --line-number --no-heading --smart-case --hidden -g '!.git' --color=always)
+
+# Build fzf command. We avoid zsh arithmetic and history expansion entirely.
+SEL="$(
+  fzf --ansi --disabled --prompt='RG   ' \
+      --bind "start:reload:printf ''" \
+      --bind "change:reload:${RG_PREFIX[*]} {q} || true" \
+      --delimiter ':' \
+      --preview 'if [ -n "{1}" ]; then (bat --style=numbers --color=always --line-range {2}: -- {1} 2>/dev/null || (tail -n +{2} -- {1} 2>/dev/null | head -n 200)); else (bat --style=numbers --color=always -- {1} 2>/dev/null || head -n 200 -- {1}); fi' \
+      --preview-window=right,60%,border,hidden \
+      --query "$QUERY" \
+      || true
+)"
+
+# Open selected match in Code at the proper line
+if [[ -n "${SEL:-}" ]]; then
+  FILE="${SEL%%:*}"; REST="${SEL#*:}"
+  LINE="${REST%%:*}"
+  if command -v code >/dev/null 2>&1; then
+    if [[ -n "$LINE" ]]; then code -r --goto "$FILE:$LINE"; else code -r -- "$FILE"; fi
+  else
+    "${VISUAL:-${EDITOR:-vi}}" "+${LINE:-1}" "$FILE"
+  fi
+fi
+exit 0

--- a/dot_zshrc
+++ b/dot_zshrc
@@ -1,19 +1,12 @@
 # shellcheck shell=bash
-export PATH="$PATH:/Users/freedebreuil/tools/depot_tools"
+export PATH="$HOME/.local/bin:$PATH:/Users/freedebreuil/tools/depot_tools"
 
 # shellcheck source=/Users/freedebreuil/.config/shell/00-editor.sh
 # shellcheck disable=SC1091
 [ -f "/Users/freedebreuil/.config/shell/00-editor.sh" ] && . "/Users/freedebreuil/.config/shell/00-editor.sh"
 
+# Load FZF theme if available
+[ -f "$HOME/.config/fzf/tokyonight.zsh" ] && source "$HOME/.config/fzf/tokyonight.zsh"
+
 # Tokyo Night Moon colors for FindItFaster
 export BAT_THEME="tokyonight_moon"
-
-if [[ $FIND_IT_FASTER_ACTIVE -eq 1 ]]; then
-    # Tokyo Night Moon color palette for fzf (requires Nerd Font for icons)
-    export FZF_DEFAULT_OPTS="\
-      --color=bg:#1a1b26,bg+:#24283b,fg:#c0caf5,fg+:#a9b1d6,\
-             hl:#7aa2f7,hl+:#7dcfff,info:#0db9d7,prompt:#bb9af7,\
-             pointer:#f7768e,marker:#ff9e64 \
-      --prompt=' ' --pointer=' ' \
-      --bind=ctrl-n:down,ctrl-p:up"
-fi


### PR DESCRIPTION
## Summary
- add Tokyonight FZF theme and reusable `vf`/`vt` search scripts
- source FZF theme and tool path in zshrc
- wire new tools into VS Code via terminal profiles and keybindings

## Testing
- `shellcheck dot_local/bin/executable_vf dot_local/bin/executable_vt`


------
https://chatgpt.com/codex/tasks/task_e_68a4f9ca8cf483248e7879515afc4735