### PR TITLE
feat: add lazygit terminal profile

### DIFF
--- a/.chezmoitemplates/vscode-keybindings.json
+++ b/.chezmoitemplates/vscode-keybindings.json
@@ -801,6 +801,11 @@
     "key": "ctrl+alt+shift+f",
     "command": "workbench.action.terminal.newWithProfile",
     "args": { "profileName": "Search Grep", "location": "editor" }
+  },
+  {
+    "key": "ctrl+alt+g",
+    "command": "workbench.action.terminal.newWithProfile",
+    "args": { "profileName": "Lazy Git", "location": "editor" }
   }
 ]
 

--- a/.chezmoitemplates/vscode-settings.json
+++ b/.chezmoitemplates/vscode-settings.json
@@ -35,6 +35,15 @@
       ],
       "icon": "search",
       "overrideName": true
+    },
+    "Lazy Git": {
+      "path": "/bin/zsh",
+      "args": [
+        "-lc",
+        "export PATH=/opt/homebrew/bin:/usr/local/bin:$PATH; source ~/.config/fzf/tokyonight.zsh 2>/dev/null; lazygit || true; exit 0"
+      ],
+      "icon": "git-branch",
+      "overrideName": true
     }
   },
 
@@ -1061,6 +1070,19 @@
       ],
       "commands": [
         "lazygit-vscode.toggle"
+      ]
+    },
+    {
+      "before": [
+        "<leader>",
+        "g",
+        "l"
+      ],
+      "commands": [
+        {
+          "command": "workbench.action.terminal.newWithProfile",
+          "args": { "profileName": "Lazy Git", "location": "editor" }
+        }
       ]
     },
     {


### PR DESCRIPTION
## Summary
- add Lazy Git terminal profile for macOS, including Vim leader mapping and hotkey

## Testing
- `pip install json5`
- `python - <<'PY'
import json5,sys
for f in ['.chezmoitemplates/vscode-settings.json','.chezmoitemplates/vscode-keybindings.json']:
    with open(f) as fh:
        json5.load(fh)
print('json5 parse ok')
PY` *(fails: ValueError: Unexpected "-" at column 3)*
- `apt-get install -y chezmoi` *(fails: Unable to locate package chezmoi)*

------
https://chatgpt.com/codex/tasks/task_e_68a63522a3308324b887192942a76291