### PR TITLE
feat(vscode): map <leader> g g to Lazy Git

### DIFF
--- a/.chezmoitemplates/vscode-settings.json
+++ b/.chezmoitemplates/vscode-settings.json
@@ -1069,7 +1069,10 @@
         "g"
       ],
       "commands": [
-        "lazygit-vscode.toggle"
+        {
+          "command": "workbench.action.terminal.newWithProfile",
+          "args": { "profileName": "Lazy Git", "location": "editor" }
+        }
       ]
     },
     {


### PR DESCRIPTION
## Summary
- map `<leader> g g` to open Lazy Git terminal profile like `<leader> g l`

## Testing
- `python - <<'PY'
import json, re
text=open('.chezmoitemplates/vscode-settings.json').read()
text=re.sub(r'//.*','', text)
json.loads(text)
print('JSON OK')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a69e9ec46083248c79abbafd2308a4