### PR TITLE
feat(vscode): add buffer switching keymaps

### DIFF
--- a/.chezmoitemplates/vscode-settings.json
+++ b/.chezmoitemplates/vscode-settings.json
@@ -359,6 +359,15 @@
         "workbench.action.splitEditorRight"
       ]
     },
+    // Buffer switching
+    {
+      "before": ["[", "b"],
+      "commands": ["workbench.action.previousEditor"]
+    },
+    {
+      "before": ["]", "b"],
+      "commands": ["workbench.action.nextEditor"]
+    },
     // Misc
     {
       "before": [


### PR DESCRIPTION
## Summary
- map `[b` to previous editor tab
- map `]b` to next editor tab

## Testing
- `pre-commit run --files .chezmoitemplates/vscode-settings.json` *(fails: .pre-commit-config.yaml is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_68a6b81182c4832491ce06428b2d7aa2