### PR TITLE
Run fzf tools through VS Code tasks

### DIFF
--- a/.chezmoitemplates/vscode-keybindings.json
+++ b/.chezmoitemplates/vscode-keybindings.json
@@ -792,20 +792,9 @@
   { "key": "ctrl+2", "command": "workbench.action.focusSecondEditorGroup" },
   { "key": "ctrl+3", "command": "workbench.action.focusThirdEditorGroup" },
   // FZF search tools
-  {
-    "key": "ctrl+alt+f",
-    "command": "workbench.action.terminal.newWithProfile",
-    "args": { "profileName": "Find Files", "location": "editor" }
-  },
-  {
-    "key": "ctrl+alt+shift+f",
-    "command": "workbench.action.terminal.newWithProfile",
-    "args": { "profileName": "Search Grep", "location": "editor" }
-  },
-  {
-    "key": "ctrl+alt+g",
-    "command": "workbench.action.terminal.newWithProfile",
-    "args": { "profileName": "Lazy Git", "location": "editor" }
-  }
+  { "key": "ctrl+alt+f", "command": "workbench.action.tasks.runTask", "args": "FF: Find Files" },
+  { "key": "ctrl+alt+shift+f", "command": "workbench.action.tasks.runTask", "args": "SG: Search Grep" },
+  { "key": "ctrl+alt+g", "command": "workbench.action.tasks.runTask", "args": "LG: LazyGit" },
+  { "key": "ctrl+alt+m", "command": "workbench.action.toggleMaximizedPanel" }
 ]
 

--- a/.chezmoitemplates/vscode-settings.json
+++ b/.chezmoitemplates/vscode-settings.json
@@ -602,8 +602,8 @@
       ],
       "commands": [
         {
-          "command": "workbench.action.terminal.newWithProfile",
-          "args": { "profileName": "Search Grep", "location": "editor" }
+          "command": "workbench.action.tasks.runTask",
+          "args": "SG: Search Grep"
         }
       ]
     },
@@ -615,8 +615,8 @@
       ],
       "commands": [
         {
-          "command": "workbench.action.terminal.newWithProfile",
-          "args": { "profileName": "Find Files", "location": "editor" }
+          "command": "workbench.action.tasks.runTask",
+          "args": "FF: Find Files"
         }
       ]
     },
@@ -628,8 +628,8 @@
       ],
       "commands": [
         {
-          "command": "workbench.action.terminal.newWithProfile",
-          "args": { "profileName": "Find Files", "location": "editor" }
+          "command": "workbench.action.tasks.runTask",
+          "args": "FF: Find Files"
         }
       ]
     },
@@ -640,8 +640,8 @@
       ],
       "commands": [
         {
-          "command": "workbench.action.terminal.newWithProfile",
-          "args": { "profileName": "Search Grep", "location": "editor" }
+          "command": "workbench.action.tasks.runTask",
+          "args": "SG: Search Grep"
         }
       ]
     },
@@ -1080,8 +1080,8 @@
       ],
       "commands": [
         {
-          "command": "workbench.action.terminal.newWithProfile",
-          "args": { "profileName": "Lazy Git", "location": "editor" }
+          "command": "workbench.action.tasks.runTask",
+          "args": "LG: LazyGit"
         }
       ]
     },

--- a/.chezmoitemplates/vscode-tasks.json
+++ b/.chezmoitemplates/vscode-tasks.json
@@ -1,0 +1,41 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "FF: Find Files",
+      "type": "shell",
+      "command": "export PATH=/opt/homebrew/bin:/usr/local/bin:$PATH; source ~/.config/fzf/tokyonight.zsh 2>/dev/null; export RIPGREP_CONFIG_PATH=~/.ripgreprc; ~/.local/bin/ff || true",
+      "options": { "shell": { "executable": "/bin/zsh", "args": ["-lc"] } },
+      "linux": {
+        "command": "export PATH=/usr/local/bin:$PATH; source ~/.config/fzf/tokyonight.zsh 2>/dev/null; export RIPGREP_CONFIG_PATH=~/.ripgreprc; ~/.local/bin/ff || true",
+        "options": { "shell": { "executable": "/bin/zsh", "args": ["-lc"] } }
+      },
+      "presentation": { "reveal": "always", "focus": true, "panel": "new", "clear": true, "close": true },
+      "problemMatcher": []
+    },
+    {
+      "label": "SG: Search Grep",
+      "type": "shell",
+      "command": "export PATH=/opt/homebrew/bin:/usr/local/bin:$PATH; source ~/.config/fzf/tokyonight.zsh 2>/dev/null; export RIPGREP_CONFIG_PATH=~/.ripgreprc; ~/.local/bin/sg || true",
+      "options": { "shell": { "executable": "/bin/zsh", "args": ["-lc"] } },
+      "linux": {
+        "command": "export PATH=/usr/local/bin:$PATH; source ~/.config/fzf/tokyonight.zsh 2>/dev/null; export RIPGREP_CONFIG_PATH=~/.ripgreprc; ~/.local/bin/sg || true",
+        "options": { "shell": { "executable": "/bin/zsh", "args": ["-lc"] } }
+      },
+      "presentation": { "reveal": "always", "focus": true, "panel": "new", "clear": true, "close": true },
+      "problemMatcher": []
+    },
+    {
+      "label": "LG: LazyGit",
+      "type": "shell",
+      "command": "export PATH=/opt/homebrew/bin:/usr/local/bin:$PATH; source ~/.config/fzf/tokyonight.zsh 2>/dev/null; lazygit || true",
+      "options": { "shell": { "executable": "/bin/zsh", "args": ["-lc"] } },
+      "linux": {
+        "command": "export PATH=/usr/local/bin:$PATH; source ~/.config/fzf/tokyonight.zsh 2>/dev/null; lazygit || true",
+        "options": { "shell": { "executable": "/bin/zsh", "args": ["-lc"] } }
+      },
+      "presentation": { "reveal": "always", "focus": true, "panel": "new", "clear": true, "close": true },
+      "problemMatcher": []
+    }
+  ]
+}

--- a/AppData/Roaming/Code/User/tasks.json.tmpl
+++ b/AppData/Roaming/Code/User/tasks.json.tmpl
@@ -1,0 +1,1 @@
+{{- template "vscode-tasks.json" . -}}

--- a/Library/Application Support/Code/User/tasks.json.tmpl
+++ b/Library/Application Support/Code/User/tasks.json.tmpl
@@ -1,0 +1,1 @@
+{{- template "vscode-tasks.json" . -}}

--- a/dot_config/Code/User/tasks.json.tmpl
+++ b/dot_config/Code/User/tasks.json.tmpl
@@ -1,0 +1,1 @@
+{{- template "vscode-tasks.json" . -}}


### PR DESCRIPTION
## Summary
- add VS Code tasks for ff, sg, and lazygit with auto-closing terminals
- trigger the new tasks from keybindings and add a panel maximizer shortcut
- map Vim leader shortcuts to invoke the tasks instead of terminal profiles

## Testing
- `NODE_PATH=$(npm root -g) node -e "const { parse } = require('jsonc-parser'); const fs = require('fs'); parse(fs.readFileSync('.chezmoitemplates/vscode-settings.json', 'utf8')); console.log('ok');"`
- `jq empty .chezmoitemplates/vscode-tasks.json`


------
https://chatgpt.com/codex/tasks/task_e_68a6c20a13708324aab3d9fd36f541cb