### PR TITLE
install oh-my-zsh via chezmoi

### DIFF
--- a/dot_zshrc
+++ b/dot_zshrc
@@ -1,4 +1,9 @@
 # shellcheck shell=bash
+export ZSH="$HOME/.oh-my-zsh"
+ZSH_THEME="robbyrussell"
+plugins=(git)
+source "$ZSH/oh-my-zsh.sh"
+
 export PATH="$HOME/.local/bin:$PATH:/Users/freedebreuil/tools/depot_tools"
 
 # shellcheck source=/Users/freedebreuil/.config/shell/00-editor.sh

--- a/run_once_25-install-oh-my-zsh.sh.tmpl
+++ b/run_once_25-install-oh-my-zsh.sh.tmpl
@@ -1,0 +1,13 @@
+{{ if ne .chezmoi.os "windows" -}}
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -d "$HOME/.oh-my-zsh" ]; then
+  exit 0
+fi
+
+export RUNZSH=no
+export CHSH=no
+export KEEP_ZSHRC=yes
+sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" --unattended
+{{ end -}}


### PR DESCRIPTION
## Summary
- install oh-my-zsh automatically using a chezmoi run_once script
- load oh-my-zsh in zshrc while preserving existing settings

## Testing
- `shellcheck run_once_25-install-oh-my-zsh.sh.tmpl dot_zshrc`

------
https://chatgpt.com/codex/tasks/task_e_68a8b0f250f48324b67358e7d940c249