### PR TITLE
feat(vscode): add explorer toggle with leader e

### DIFF
--- a/.chezmoitemplates/vscode-keybindings.json
+++ b/.chezmoitemplates/vscode-keybindings.json
@@ -764,6 +764,11 @@
   { "key": "ctrl+b", "command": "workbench.action.focusSideBar", "when": "!sideBarFocus" },
   { "key": "ctrl+b", "command": "workbench.action.closeSidebar", "when": "sideBarFocus" },
 
+  // Toggle Explorer with Space e
+  { "key": "space e", "command": "workbench.view.explorer", "when": "!explorerViewletVisible && !editorTextFocus" },
+  { "key": "space e", "command": "workbench.files.action.focusFilesExplorer", "when": "explorerViewletVisible && !filesExplorerFocus && !editorTextFocus" },
+  { "key": "space e", "command": "workbench.action.closeSidebar", "when": "explorerViewletVisible && filesExplorerFocus && !editorTextFocus" },
+
   // Bottom Panel (Terminal/Problems/Output/Debug Console)
   { "key": "cmd+j",  "command": "workbench.action.focusPanel", "when": "!panelFocus" },
   { "key": "cmd+j",  "command": "workbench.action.closePanel", "when": "panelFocus" },


### PR DESCRIPTION
## Summary
- toggle VS Code Explorer with `<space>e`
- open, focus, or close Explorer depending on visibility
- disable `<space>e` keybinding when editor (vim) is focused

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a93fb2afb8832483950bf680808b4c