### PR TITLE
fix: remove tilde from JetBrains Mono external paths

### DIFF
--- a/.chezmoiexternal.toml.tmpl
+++ b/.chezmoiexternal.toml.tmpl
@@ -5,7 +5,7 @@
 
 # macOS - install under user's Fonts
 {{- if eq .chezmoi.os "darwin" }}
-["~/Library/Fonts/JetBrainsMono"]
+["Library/Fonts/JetBrainsMono"]
 type = "archive"
 # Option A: GitHub release asset (static URL, no API call)
 url = "https://github.com/JetBrains/JetBrainsMono/releases/download/{{ $ver }}/JetBrainsMono-{{ $vernum }}.zip"
@@ -19,7 +19,7 @@ refreshPeriod = "720h"
 
 # Linux - user fonts dir, subfolder is fine for fc-cache
 {{- if eq .chezmoi.os "linux" }}
-["~/.local/share/fonts/JetBrainsMono"]
+[".local/share/fonts/JetBrainsMono"]
 type = "archive"
 url = "https://github.com/JetBrains/JetBrainsMono/releases/download/{{ $ver }}/JetBrainsMono-{{ $vernum }}.zip"
 # url = "https://download.jetbrains.com/fonts/JetBrainsMono-{{ $vernum }}.zip"
@@ -31,7 +31,7 @@ refreshPeriod = "720h"
 
 # Windows - per-user fonts location
 {{- if eq .chezmoi.os "windows" }}
-["~/AppData/Local/Microsoft/Windows/Fonts/JetBrainsMono"]
+["AppData/Local/Microsoft/Windows/Fonts/JetBrainsMono"]
 type = "archive"
 url = "https://github.com/JetBrains/JetBrainsMono/releases/download/{{ $ver }}/JetBrainsMono-{{ $vernum }}.zip"
 # url = "https://download.jetbrains.com/fonts/JetBrainsMono-{{ $vernum }}.zip"


### PR DESCRIPTION
## Summary
- remove leading tilde from JetBrains Mono external entries so paths resolve correctly on macOS, Linux, and Windows

## Testing
- `chezmoi --version`
- `chezmoi --source=. execute-template '{{ joinPath .chezmoi.homeDir "Library" "Fonts" "JetBrainsMono" "JetBrainsMono-Bold.ttf" }}'`


------
https://chatgpt.com/codex/tasks/task_e_68a9a51ec38c83248a01db010dcfcb59