### PR TITLE
feat: highlight VS Code IntelliSense selection

### DIFF
--- a/.chezmoitemplates/vscode-settings.json
+++ b/.chezmoitemplates/vscode-settings.json
@@ -72,7 +72,10 @@
     "editor.lineHighlightBackground": "#2F334D",
     "editorLineNumber.activeForeground": "#FF9E3B",
     "editor.selectionBackground": "#313F72",
-    "editor.background": "#222436"
+    "editor.background": "#222436",
+    "editorSuggestWidget.selectedBackground": "#2F334D",
+    "editorSuggestWidget.selectedForeground": "#FFFFFF",
+    "editorSuggestWidget.selectedIconForeground": "#FFFFFF"
   },
   "workbench.quickOpen.centered": true,
   "window.commandCenter": false,


### PR DESCRIPTION
## Summary
- align IntelliSense selection colors with editor line highlight

## Testing
- `chezmoi execute-template < .chezmoitemplates/vscode-settings.json > /tmp/rendered.json`
- `rg "editorSuggestWidget.selectedBackground" /tmp/rendered.json`


------
https://chatgpt.com/codex/tasks/task_e_68a9a57199748324818107c93a3ebc8e