### PR TITLE
Ensure fzf uses full-screen height

### DIFF
--- a/dot_local/bin/executable_ff
+++ b/dot_local/bin/executable_ff
@@ -63,6 +63,7 @@ while true; do
     | decorate \
     | FZF_DEFAULT_OPTS="${FZF_DEFAULT_OPTS-}" \
       fzf --read0 --ansi \
+          --height=100% \
           --prompt="$prompt" \
           --delimiter='\t' \
           --with-nth=1,2 \

--- a/dot_local/bin/executable_sg
+++ b/dot_local/bin/executable_sg
@@ -97,6 +97,7 @@ FZF_ARGS=(
   --bind "start:reload:${RELOAD_CMD}"
   --bind "change:reload:${RELOAD_CMD}"
   --prompt='> '
+  --height=100%
   --margin=1,2           # float-like feel
   --header='' # keep top clean just like LazyVim Grep
   --border --layout=reverse


### PR DESCRIPTION
## Summary
- override height in fzf invocations so scripts ignore FZF_DEFAULT_OPTS

## Testing
- `shellcheck dot_local/bin/executable_ff dot_local/bin/executable_sg`


------
https://chatgpt.com/codex/tasks/task_e_68ace07d53508324a9bfd157fc1d941e