### PR TITLE
feat(vscode): focus editor when terminal Esc pressed

### DIFF
--- a/.chezmoitemplates/vscode-keybindings.json
+++ b/.chezmoitemplates/vscode-keybindings.json
@@ -26,6 +26,12 @@
     "command": "extension.vim_escape",
     "when": "editorTextFocus && vim.active && !inDebugRepl && !lazygitFocus"
   },
+  // Focus the active editor when Esc is pressed in the panel terminal
+  {
+    "key": "escape",
+    "command": "workbench.action.focusActiveEditorGroup",
+    "when": "terminalFocus && terminalLocation == 'panel' && !lazygitFocus"
+  },
 {{- if eq .chezmoi.os "darwin" }}
   // ----- Word navigation on ⌘ + ← / → -----
   // Remove defaults (line start/end) that would conflict:

--- a/.chezmoitemplates/vscode-settings.json
+++ b/.chezmoitemplates/vscode-settings.json
@@ -66,6 +66,9 @@
   "terminal.integrated.hideOnLastClosed": true,
   "terminal.integrated.hideOnStartup": true,
   "terminal.integrated.showExitAlert": false,
+  "terminal.integrated.commandsToSkipShell": [
+    "workbench.action.focusActiveEditorGroup"
+  ],
   "editor.lineNumbers": "relative",
   "editor.renderLineHighlight": "all",
   "workbench.colorTheme": "Tokyo Night Storm",


### PR DESCRIPTION
## Summary
- ensure Esc in panel terminal jumps focus back to the editor
- let VS Code handle Esc by skipping the shell for this command

## Testing
- `chezmoi doctor` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68accaf153ec8324b8eb286afd0c6ea9