### PR TITLE
fix: stabilize CI node setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install stow and dry-run (Unix)
         if: runner.os != 'Windows'
@@ -62,14 +62,17 @@ jobs:
         if: runner.os != 'Windows'
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          # Use stable LTS for best tooling compatibility
+          node-version: '20'
+          # Keep caching enabled, but don't force a specific lockfile path.
+          # setup-node v4 fails the job if the provided path doesn't exist.
           cache: npm
-          cache-dependency-path: tests/package-lock.json
 
       - name: Install test deps (Unix)
         if: runner.os != 'Windows'
         working-directory: tests
-        run: npm install
+        run: |
+          if [ -f package-lock.json ]; then npm ci; else npm install; fi
 
       - name: Run TS Stow tests (Unix)
         if: runner.os != 'Windows'


### PR DESCRIPTION
## Summary
- switch actions/checkout to v4
- use Node 20 LTS and remove brittle cache lockfile path
- install test deps resiliently

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1b688c2008324b0008dc2b39b7589