### PR TITLE
Add CLI and bootstrap coverage tests

### DIFF
--- a/tests/_helpers.ts
+++ b/tests/_helpers.ts
@@ -1,0 +1,49 @@
+import { mkdtempSync, writeFileSync, mkdirSync, chmodSync, readFileSync, readdirSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
+import { execFile as _execFile } from 'child_process';
+import { promisify } from 'util';
+
+const execFile = promisify(_execFile);
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+export const repoRoot = resolve(__dirname, '..');
+
+export function makeTmpDir(prefix: string) {
+  return mkdtempSync(join(tmpdir(), `${prefix}-`));
+}
+
+export function makeBin(dir: string, name: string, body: string) {
+  const p = join(dir, name);
+  writeFileSync(p, `#!/usr/bin/env bash\nset -euo pipefail\n${body}\n`);
+  chmodSync(p, 0o755);
+  return p;
+}
+
+export async function runDot(args: string[], opts?: { env?: Record<string, string>; cwd?: string }) {
+  const bin = resolve(repoRoot, 'dot');
+  const { stdout, stderr } = await execFile(bin, args, {
+    cwd: opts?.cwd ?? repoRoot,
+    env: { ...process.env, ...(opts?.env ?? {}) }
+  });
+  return { stdout: String(stdout), stderr: String(stderr) };
+}
+
+export function read(path: string) {
+  return readFileSync(path, 'utf8');
+}
+
+export function list(dir: string) {
+  return readdirSync(dir);
+}
+
+export function exists(path: string) {
+  return existsSync(path);
+}
+
+export function parsePackagesFromBanner(out: string): string[] {
+  const m = out.match(/packages:\s*([^\n]+)/);
+  if (!m) return [];
+  return m[1].trim().split(/\s+/).filter(Boolean);
+}

--- a/tests/bootstrap.dryrun.test.ts
+++ b/tests/bootstrap.dryrun.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { makeTmpDir, makeBin, repoRoot } from './_helpers.js';
+import { execFile as _execFile } from 'child_process';
+import { promisify } from 'util';
+import { join } from 'path';
+const execFile = promisify(_execFile);
+
+describe('bootstrap.sh DRYRUN', () => {
+  it('prints DRYRUN banner and completes', async () => {
+    const stubs = makeTmpDir('stubs');
+    makeBin(stubs, 'stow', `:`);
+
+    const PATH = `${stubs}:${process.env.PATH}`;
+    const { stdout } = await execFile(join(repoRoot, 'scripts/bootstrap.sh'), [], {
+      env: { ...process.env, DRYRUN: '1', PATH },
+      cwd: repoRoot
+    });
+
+    expect(stdout).toMatch(/DRYRUN=1: skipping installations; previewing stow changes/i);
+    expect(stdout).toMatch(/✅ Bootstrap complete\./);
+  });
+});

--- a/tests/dot.commands.test.ts
+++ b/tests/dot.commands.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { makeTmpDir, makeBin, runDot, repoRoot, read } from './_helpers.js';
+import { join } from 'path';
+
+function setupStubbedPATH(env: Record<string, string> = {}) {
+  const tmp = makeTmpDir('stubs');
+  const log = join(tmp, 'stow.log');
+
+  makeBin(tmp, 'stow', `
+    echo "$@" >> "\${LOG}"
+  `);
+
+  const PATH = `${tmp}:${process.env.PATH}`;
+  return { PATH, tmp, log, env: { ...env, LOG: log } };
+}
+
+describe('dot subcommand wiring', () => {
+  it('diff uses -n -v and -S', async () => {
+    const { PATH, env, log } = setupStubbedPATH();
+    const target = makeTmpDir('home');
+    const { stdout } = await runDot(['diff', '--target', target, 'foo'], { env: { PATH, ...env } });
+    const line = read(log).trim();
+    expect(line).toContain('-n');
+    expect(line).toContain('-v');
+    expect(line).toContain('-S foo');
+    expect(stdout).toMatch(/dot diff: os=/);
+  });
+
+  it('apply uses -S', async () => {
+    const { PATH, env, log } = setupStubbedPATH();
+    const target = makeTmpDir('home');
+    await runDot(['apply', '--target', target, 'foo', 'bar'], { env: { PATH, ...env } });
+    const line = read(log).trim().split('\n').pop()!;
+    expect(line).toContain('-S foo bar');
+  });
+
+  it('restow uses -R', async () => {
+    const { PATH, env, log } = setupStubbedPATH();
+    const target = makeTmpDir('home');
+    await runDot(['restow', '--target', target, 'pkg1'], { env: { PATH, ...env } });
+    const line = read(log).trim();
+    expect(line).toContain('-R pkg1');
+  });
+
+  it('delete uses -D', async () => {
+    const { PATH, env, log } = setupStubbedPATH();
+    const target = makeTmpDir('home');
+    await runDot(['delete', '--target', target, 'pkgZ'], { env: { PATH, ...env } });
+    const line = read(log).trim();
+    expect(line).toContain('-D pkgZ');
+  });
+
+  it('update calls git pull then restow (-R)', async () => {
+    const tmp = makeTmpDir('stubs');
+    const stowLog = join(tmp, 'stow.log');
+    const gitLog = join(tmp, 'git.log');
+
+    makeBin(tmp, 'stow', `echo "$@" >> "\${STOW_LOG}"`);
+    makeBin(tmp, 'git', `echo "git $@" >> "\${GIT_LOG}"`);
+
+    const PATH = `${tmp}:${process.env.PATH}`;
+    const target = makeTmpDir('home');
+    await runDot(['update', '--target', target, 'abc'], {
+      env: { PATH, STOW_LOG: stowLog, GIT_LOG: gitLog }
+    });
+
+    const gitLine = read(gitLog).trim();
+    expect(gitLine).toMatch(/git -C .*dotfiles.* pull --ff-only/);
+
+    const stowLine = read(stowLog).trim().split('\n').pop()!;
+    expect(stowLine).toContain('-R abc');
+  });
+});

--- a/tests/dot.conflicts.test.ts
+++ b/tests/dot.conflicts.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { makeTmpDir, makeBin, runDot, list, exists } from './_helpers.js';
+import { join } from 'path';
+import { writeFileSync } from 'fs';
+
+describe('backup_conflicts', () => {
+  it('backs up conflicting target with .pre-stow.<timestamp>', async () => {
+    const tmp = makeTmpDir('stubs');
+    const stowLog = join(tmp, 'stow.log');
+
+    makeBin(tmp, 'stow', `
+      echo "$@" >> "\${LOG}"
+      if [[ "$*" == *"-n"* && "$*" == *"-v"* && "$*" == *" -S "* && -n "\${CONFLICT:-}" ]]; then
+        echo "WARNING: existing target is not owned by stow: \${CONFLICT}"
+      fi
+    `);
+
+    const PATH = `${tmp}:${process.env.PATH}`;
+    const target = makeTmpDir('home');
+    const victim = '.zshrc';
+    const victimPath = join(target, victim);
+    writeFileSync(victimPath, 'user stuff', 'utf8');
+
+    await runDot(['apply', '--target', target, 'zsh'], {
+      env: { PATH, LOG: stowLog, CONFLICT: victim }
+    });
+
+    expect(exists(victimPath)).toBe(false);
+    const backups = list(target).filter((f) => f.startsWith('.zshrc.pre-stow.'));
+    expect(backups.length).toBe(1);
+  });
+});

--- a/tests/dot.default-packages.test.ts
+++ b/tests/dot.default-packages.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { makeTmpDir, makeBin, runDot, parsePackagesFromBanner } from './_helpers.js';
+
+function setupWithUname(fake: 'Darwin' | 'Linux') {
+  const tmp = makeTmpDir('stubs');
+  makeBin(tmp, 'uname', `[[ "\${1:-}" == "-s" ]] && echo "\${FAKE}" || echo "\${FAKE}"`);
+  makeBin(tmp, 'stow', `:`);
+  const PATH = `${tmp}:${process.env.PATH}`;
+  return { PATH, FAKE: fake };
+}
+
+describe('default packages per OS', () => {
+  it('Darwin includes hammerspoon and excludes vsvim', async () => {
+    const { PATH, FAKE } = setupWithUname('Darwin');
+    const target = makeTmpDir('home');
+    const { stdout } = await runDot(['diff', '--target', target], { env: { PATH, FAKE } });
+    const pkgs = parsePackagesFromBanner(stdout);
+    expect(pkgs).toContain('hammerspoon');
+    expect(pkgs).not.toContain('vsvim');
+  });
+
+  it('Linux excludes hammerspoon and vsvim', async () => {
+    const { PATH, FAKE } = setupWithUname('Linux');
+    const target = makeTmpDir('home');
+    const { stdout } = await runDot(['diff', '--target', target], { env: { PATH, FAKE } });
+    const pkgs = parsePackagesFromBanner(stdout);
+    expect(pkgs).not.toContain('hammerspoon');
+    expect(pkgs).not.toContain('vsvim');
+  });
+});


### PR DESCRIPTION
## Summary
- add helper utilities for test stubs
- cover dot CLI subcommand wiring and OS-aware defaults
- verify conflict backups and bootstrap dry-run path

## Testing
- `./dot test`


------
https://chatgpt.com/codex/tasks/task_e_68b2a35e847c8324bc7788b120d8eae1