### PR TITLE
Add Zoekt real-time search tooling

### DIFF
--- a/bin/Register-ZoektOverlayTask.ps1
+++ b/bin/Register-ZoektOverlayTask.ps1
@@ -1,0 +1,4 @@
+$script = "$env:USERPROFILE\bin\Watch-ZoektOverlay.ps1"
+$trigger = New-ScheduledTaskTrigger -AtLogOn
+$action  = New-ScheduledTaskAction -Execute "powershell.exe" -Argument "-NoLogo -ExecutionPolicy Bypass -File `"$script`""
+Register-ScheduledTask -TaskName "ZoektOverlayWatch" -Trigger $trigger -Action $action -Description "Real-time Zoekt overlay watch" -User $env:UserName -Force

--- a/bin/Update-ZoektOverlayIndex.ps1
+++ b/bin/Update-ZoektOverlayIndex.ps1
@@ -1,0 +1,44 @@
+param(
+  [string]$ChromiumSrc = $env:CHROMIUM_SRC,
+  [string]$OverlayDir  = "$env:USERPROFILE\.zoekt\chromium-overlay"
+)
+$ErrorActionPreference = 'Stop'
+if (-not (Test-Path $ChromiumSrc)) { throw "ChromiumSrc not found: $ChromiumSrc" }
+
+$stage = Join-Path $OverlayDir "stage"
+Remove-Item -Recurse -Force -ErrorAction SilentlyContinue "$stage"
+Get-ChildItem $OverlayDir -Filter *.zoekt* | Remove-Item -Force -ErrorAction SilentlyContinue
+New-Item -ItemType Directory -Force -Path $stage | Out-Null
+
+$changed = @()
+$deleted = @()
+
+# Gather changes across nested repos
+Get-ChildItem -Path $ChromiumSrc -Recurse -Force -Directory -Filter ".git" -ErrorAction SilentlyContinue |
+  ForEach-Object {
+    $repo = Split-Path -Parent $_.FullName
+    Push-Location $repo
+    $changed += (git ls-files -m -o --exclude-standard)
+    $deleted += (git ls-files -d)
+    Pop-Location
+  }
+
+$ignore = '^out/|^\.git/|^\.cipd/'
+$changed = $changed | Where-Object {$_ -notmatch $ignore}
+$deleted = $deleted | Where-Object {$_ -notmatch $ignore}
+
+# Stage changed files (copy on Windows for reliability)
+foreach ($rel in $changed) {
+  $src = Join-Path $ChromiumSrc $rel
+  $dst = Join-Path $stage $rel
+  New-Item -ItemType Directory -Force -Path (Split-Path $dst) | Out-Null
+  Copy-Item $src $dst -Force
+}
+
+# Save deleted list for rgx filtering
+$deleted | Set-Content (Join-Path $OverlayDir "deleted.list")
+
+# Build overlay shard
+$env:Path = "$(if ($env:GOBIN) {"$env:GOBIN;"})$env:Path"
+& zoekt-index -index $OverlayDir $stage | Out-Null
+Write-Host "[zoekt] Overlay updated: $($changed.Count) changed, $($deleted.Count) deleted."

--- a/bin/Watch-ZoektOverlay.ps1
+++ b/bin/Watch-ZoektOverlay.ps1
@@ -1,0 +1,35 @@
+param(
+  [string]$ChromiumSrc = $env:CHROMIUM_SRC,
+  [string]$OverlayDir = "$env:USERPROFILE\.zoekt\chromium-overlay"
+)
+$ErrorActionPreference = 'Stop'
+if (-not (Test-Path $ChromiumSrc)) { throw "Set CHROMIUM_SRC first." }
+
+# Initial build
+& "$env:USERPROFILE\bin\Update-ZoektOverlayIndex.ps1" -ChromiumSrc $ChromiumSrc -OverlayDir $OverlayDir
+
+$fsw = New-Object IO.FileSystemWatcher $ChromiumSrc, '*'
+$fsw.IncludeSubdirectories = $true
+$fsw.NotifyFilter = [IO.NotifyFilters]'FileName, LastWrite, DirectoryName'
+
+# Debounce timer (1s)
+$pending = $false
+$timer = New-Object Timers.Timer
+$timer.Interval = 1000
+$timer.AutoReset = $false
+$timer.add_Elapsed({
+  if ($pending) {
+    $pending = $false
+    & "$env:USERPROFILE\bin\Update-ZoektOverlayIndex.ps1" -ChromiumSrc $ChromiumSrc -OverlayDir $OverlayDir
+  }
+})
+
+$action = { $ExecutionContext.SessionState.PSVariable.Set('pending',$true); $timer.Stop(); $timer.Start() }
+$subs = @()
+$subs += Register-ObjectEvent $fsw Changed -Action $action
+$subs += Register-ObjectEvent $fsw Created -Action $action
+$subs += Register-ObjectEvent $fsw Deleted -Action $action
+$subs += Register-ObjectEvent $fsw Renamed -Action $action
+
+Write-Host "[zoekt] Watching $ChromiumSrc for changes. Ctrl+C to stop."
+while ($true) { Wait-Event | Out-Null }

--- a/bin/rgx.ps1
+++ b/bin/rgx.ps1
@@ -1,0 +1,40 @@
+param(
+  [Parameter(Position=0)][string]$Query,
+  [string]$Root = (Get-Location).Path,
+  [string]$IndexDir = "$env:USERPROFILE\.zoekt\chromium",
+  [string]$OverlayDir = "$env:USERPROFILE\.zoekt\chromium-overlay",
+  [switch]$Literal, [switch]$IgnoreCase, [switch]$SmartCase
+)
+$ErrorActionPreference = 'Stop'
+if (-not $Query) { Write-Error "Usage: rgx.ps1 -Query 'pattern' [-Root path]"; exit 2 }
+
+$pattern = if ($Literal) { [Regex]::Escape($Query) } else { $Query }
+$case = if ($IgnoreCase) { "case:no " } elseif ($SmartCase) { "case:auto " } else { "" }
+$Q = "$case$pattern"
+
+# Load changed and deleted file lists to suppress stale HEAD matches
+$changed = @()
+if (git rev-parse --is-inside-work-tree 2>$null) {
+  $changed = git status --porcelain | ForEach-Object { $_.Substring(3) }
+}
+$deletedList = Join-Path $OverlayDir "deleted.list"
+$deleted = Test-Path $deletedList ? (Get-Content $deletedList) : @()
+
+# Search overlay first
+$overlay = & zoekt -index $OverlayDir $Q 2>$null
+
+# Search head, filter duplicates/deletions
+$head = & zoekt -index $IndexDir $Q 2>$null | Where-Object {
+  if ($_ -match '^(.*?):(\d+):(\d+):') {
+    $f = $Matches[1]
+    -not ($changed -contains $f) -and -not ($deleted -contains $f)
+  } else { $true }
+}
+
+# Merge and print in VS-clickable format: file(line,col): text
+foreach ($ln in @($overlay) + @($head)) {
+  if ($ln -match '^(.*?):(\d+):(\d+):(.*)$') {
+    $path,$line,$col,$text = $Matches[1..4]
+    Write-Output ("{0}({1},{2}): {3}" -f $path,$line,$col,$text)
+  } else { Write-Output $ln }
+}

--- a/dot_config/git/template/hooks/post-checkout
+++ b/dot_config/git/template/hooks/post-checkout
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+repo="$(git rev-parse --show-toplevel)"
+zoekt-git-index -index "${ZOEKT_INDEX_DIR:-$HOME/.zoekt/chromium}" -branches HEAD -incremental "$repo" >/dev/null 2>&1 || true

--- a/dot_config/git/template/hooks/post-commit
+++ b/dot_config/git/template/hooks/post-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+repo="$(git rev-parse --show-toplevel)"
+zoekt-git-index -index "${ZOEKT_INDEX_DIR:-$HOME/.zoekt/chromium}" -branches HEAD -incremental "$repo" >/dev/null 2>&1 || true

--- a/dot_config/git/template/hooks/post-merge
+++ b/dot_config/git/template/hooks/post-merge
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+repo="$(git rev-parse --show-toplevel)"
+zoekt-git-index -index "${ZOEKT_INDEX_DIR:-$HOME/.zoekt/chromium}" -branches HEAD -incremental "$repo" >/dev/null 2>&1 || true

--- a/dot_config/systemd/user/zoekt-chromium-index.service
+++ b/dot_config/systemd/user/zoekt-chromium-index.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Zoekt incremental HEAD index for Chromium
+
+[Service]
+Type=oneshot
+Environment=CHROMIUM_SRC=%h/src/chromium/src
+ExecStart=%h/.local/bin/zoekt-index-chromium

--- a/dot_config/systemd/user/zoekt-chromium-index.timer
+++ b/dot_config/systemd/user/zoekt-chromium-index.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Update HEAD index regularly
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=10min
+AccuracySec=30s
+
+[Install]
+WantedBy=timers.target

--- a/dot_config/systemd/user/zoekt-chromium-overlay.service
+++ b/dot_config/systemd/user/zoekt-chromium-overlay.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Zoekt overlay watcher (working tree)
+
+[Service]
+Type=simple
+Environment=CHROMIUM_SRC=%h/src/chromium/src
+ExecStart=%h/.local/bin/zoekt-overlay-watch
+Restart=always
+RestartSec=2

--- a/dot_local/bin/executable_install-zoekt-githooks
+++ b/dot_local/bin/executable_install-zoekt-githooks
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+CHROMIUM_SRC="${1:-${CHROMIUM_SRC:-}}"
+[[ -d "$CHROMIUM_SRC" ]] || { echo "Give chromium src root"; exit 2; }
+for g in $(find "$CHROMIUM_SRC" -type d -name .git); do
+  h="$(dirname "$g")/.git/hooks"
+  mkdir -p "$h"
+  for x in post-commit post-merge post-checkout; do
+    install -m 0755 "$HOME/.config/git/template/hooks/$x" "$h/$x"
+  done
+done

--- a/dot_local/bin/executable_rgx
+++ b/dot_local/bin/executable_rgx
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Subset of ripgrep flags -> Zoekt query
+FIXED=0; IGNORE_CASE=0; SMART=0; WORD=0
+INCLUDE_GLOBS=(); EXCLUDE_GLOBS=(); TYPES=(); PATTERN=""; PATHS=()
+
+usage(){ cat <<'USAGE'
+Usage: rgx [OPTIONS] <pattern> [PATH...]
+Options: -F -i -S -w -g/--glob GLOB [-t LANG]  --  (subset of ripgrep)
+Env: ZOEKT_INDEX_DIR (HEAD), ZOEKT_OVERLAY_DIR (working tree), RGX_FORMAT=vs|vimgrep
+USAGE
+}
+
+escape_re(){ sed -e 's/[.^$\\*+?(){}\[\]|]/\\\&/g'; }
+glob_to_re(){ local g="$1"; g="${g//\\\\/\/}"; g="${g//\./\\.}"; g="${g//\*\*/.*}"; g="${g//\*/[^/]*}"; g="${g//\?/.}"; printf '%s' "$g"; }
+
+while (( $# )); do
+  case "$1" in
+    -F|--fixed-strings) FIXED=1; shift;;
+    -i) IGNORE_CASE=1; shift;;
+    -S) SMART=1; shift;;
+    -w) WORD=1; shift;;
+    -g|--glob|--glob=*)
+      val="${1#--glob=}"; [[ "$val" == "$1" ]] && { val="$2"; shift; }
+      if [[ "$val" == !* ]]; then EXCLUDE_GLOBS+=("${val:1}"); else INCLUDE_GLOBS+=("$val"); fi
+      shift;;
+    -t) TYPES+=("$2"); shift 2;;
+    -h|--help) usage; exit 0;;
+    --) shift; break;;
+    -*) shift;; # passthrough ignored; use ripgrep for special cases
+    *) if [[ -z "$PATTERN" ]]; then PATTERN="$1"; else PATHS+=("$1"); fi; shift;;
+  esac
+done
+while (( $# )); do PATHS+=("$1"); shift; done
+[[ -n "$PATTERN" ]] || { usage >&2; exit 2; }
+
+P="$PATTERN"
+[[ $FIXED -eq 1 ]] && P="$(printf '%s' "$P" | escape_re)"
+[[ $WORD  -eq 1 ]] && P="\\b${P}\\b"
+
+CASE=""
+[[ $IGNORE_CASE -eq 1 ]] && CASE="case:no"
+[[ $SMART -eq 1 ]] && CASE="${CASE:-case:auto}"
+
+FILTERS=()
+for g in "${INCLUDE_GLOBS[@]}"; do FILTERS+=("file:$(glob_to_re "$g")"); done
+for g in "${EXCLUDE_GLOBS[@]}"; do FILTERS+=("-file:$(glob_to_re "$g")"); done
+for p in "${PATHS[@]}"; do FILTERS+=("file:$(glob_to_re "$p")"); done
+for t in "${TYPES[@]}"; do
+  case "$t" in
+    c|cpp|cc|cxx) FILTERS+=("file:(\\.c$|\\.cc$|\\.cpp$|\\.cxx$|\\.h$|\\.hh$|\\.hpp$|\\.hxx$)");;
+    js|ts)        FILTERS+=("file:(\\.js$|\\.jsx$|\\.ts$|\\.tsx$)");;
+    go)           FILTERS+=("file:(\\.go$)");; py|python) FILTERS+=("file:(\\.py$)");;
+    rs|rust)      FILTERS+=("file:(\\.rs$)");;
+  esac
+done
+
+Q=""
+[[ -n "$CASE" ]] && Q="$CASE "
+for f in "${FILTERS[@]}"; do Q+="$f "; done
+Q+="$P"
+
+INDEX_DIR="${ZOEKT_INDEX_DIR:-$HOME/.zoekt/chromium}"
+OVERLAY_DIR="${ZOEKT_OVERLAY_DIR:-$HOME/.zoekt/chromium-overlay}"
+ZOEKTCMD="${ZOEKTCMD:-zoekt}"
+
+# Build changed+deleted set to filter HEAD duplicates.
+declare -A CHSET=()
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  while read -r f; do [[ -n "$f" ]] && CHSET["$f"]=1; done < <(git status --porcelain | awk '{print $2}')
+fi
+if [[ -f "$OVERLAY_DIR/deleted.list" ]]; then
+  while read -r f; do CHSET["$f"]=1; done < "$OVERLAY_DIR/deleted.list"
+fi
+
+tmp_overlay="$(mktemp)"; tmp_head="$(mktemp)"
+trap 'rm -f "$tmp_overlay" "$tmp_head"' EXIT
+
+# 1) Overlay first (latest edits). zoekt prints: path:line:col: text
+"$ZOEKTCMD" -index "$OVERLAY_DIR" "$Q" > "$tmp_overlay" 2>/dev/null || true
+
+# 2) Head index, but drop files that are in CHSET (changed/deleted)
+"$ZOEKTCMD" -index "$INDEX_DIR" "$Q" | awk -F: -v OFS=: '
+  BEGIN{ while ((getline < '"$OVERLAY_DIR"'/deleted.list)>0) del[$0]=1; }
+  {
+    file=$1; # relative path
+    if (file in del) next;
+    if (ENVIRON["CH_FILTER"]=="1") { next } # replaced below
+    print $0
+  }' > "$tmp_head"
+
+# Filter HEAD against CHSET in the shell for portability
+: > "${tmp_head}.filtered"
+while IFS= read -r line; do
+  f="${line%%:*}"
+  [[ -n "${CHSET[$f]:-}" ]] && continue
+  printf '%s\n' "$line" >> "${tmp_head}.filtered"
+done < "$tmp_head"
+
+# Merge and render Visual Studio clickable format (file(line,col): text)
+cat "$tmp_overlay" "${tmp_head}.filtered" | awk -F: '{
+  file=$1; line=$2; col=$3; $1=$2=$3=""; sub(/^ *:/,"");
+  if (ENVIRON["RGX_FORMAT"]=="vimgrep") { print file ":" line ":" col ":" $0; }
+  else { printf "%s(%s,%s): %s\n", file, line, col, $0 }
+}'

--- a/dot_local/bin/executable_zoekt-index-chromium
+++ b/dot_local/bin/executable_zoekt-index-chromium
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CHROMIUM_SRC="${1:-${CHROMIUM_SRC:-}}"
+[[ -n "$CHROMIUM_SRC" && -d "$CHROMIUM_SRC" ]] || { echo "Usage: zoekt-index-chromium /path/to/chromium/src" >&2; exit 2; }
+
+INDEX_DIR="${ZOEKT_INDEX_DIR:-$HOME/.zoekt/chromium}"
+PARALLELISM="${ZOEKT_INDEX_JOBS:-$(command -v nproc >/dev/null 2>&1 && nproc || sysctl -n hw.ncpu || echo 4)}"
+
+mapfile -t repos < <(find "$CHROMIUM_SRC" -type d -name .git -prune \
+  -not -path '*/out/*' -not -path '*/.cipd/*' -print | xargs -I{} dirname {} | sort -u)
+
+echo "[zoekt] Indexing ${#repos[@]} git repos into $INDEX_DIR ..."
+printf '%s\0' "${repos[@]}" | xargs -0 -n1 -P "$PARALLELISM" bash -c '
+  set -euo pipefail
+  repo="$1"
+  echo "  -> $repo"
+  exec zoekt-git-index -index "'"$INDEX_DIR"'" -branches HEAD -incremental "$repo"
+' bash

--- a/dot_local/bin/executable_zoekt-overlay-refresh
+++ b/dot_local/bin/executable_zoekt-overlay-refresh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CHROMIUM_SRC="${1:-${CHROMIUM_SRC:-}}"
+[[ -n "$CHROMIUM_SRC" && -d "$CHROMIUM_SRC" ]] || { echo "Usage: zoekt-overlay-refresh /path/to/chromium/src" >&2; exit 2; }
+
+OVERLAY_DIR="${ZOEKT_OVERLAY_DIR:-$HOME/.zoekt/chromium-overlay}"
+STAGE="$OVERLAY_DIR/stage"
+IGNORE='(^|/)(out/|\.git/|\.cipd/)'
+
+rm -rf "$STAGE" "$OVERLAY_DIR"/*.zoekt "$OVERLAY_DIR"/*.zoekt.idx
+mkdir -p "$STAGE"
+
+# Gather changed/untracked and deleted files from all nested git repos.
+changed=()
+deleted=()
+
+while IFS= read -r -d '' g; do
+  repo="$(dirname "$g")"
+  pushd "$repo" >/dev/null
+  while IFS= read -r f; do [[ "$f" =~ $IGNORE ]] || changed+=("$repo/$f"); done < <(git ls-files -m -o --exclude-standard)
+  while IFS= read -r f; do [[ "$f" =~ $IGNORE ]] || deleted+=("$repo/$f"); done < <(git ls-files -d)
+  popd >/dev/null
+done < <(find "$CHROMIUM_SRC" -type d -name .git -print0)
+
+# Stage changed/untracked files via symlinks preserving relative paths.
+for f in "${changed[@]}"; do
+  rel="${f#$CHROMIUM_SRC/}"
+  dest="$STAGE/$rel"
+  mkdir -p "$(dirname "$dest")"
+  ln -s "$f" "$dest" 2>/dev/null || cp -p "$f" "$dest"
+done
+
+# Record deletions so rgx can suppress stale HEAD results for those paths.
+printf '%s\n' "${deleted[@]#$CHROMIUM_SRC/}" > "$OVERLAY_DIR/deleted.list"
+
+# Build the overlay Zoekt shard from the stage tree (non-git indexer).
+# zoekt-index walks a filesystem tree and writes shards to opts.IndexDir.
+zoekt-index -index "$OVERLAY_DIR" "$STAGE"
+echo "[zoekt] Overlay index refreshed: $(wc -l < "$OVERLAY_DIR/deleted.list") deleted, ${#changed[@]} changed/untracked."

--- a/dot_local/bin/executable_zoekt-overlay-watch
+++ b/dot_local/bin/executable_zoekt-overlay-watch
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+CHROMIUM_SRC="${1:-${CHROMIUM_SRC:-}}"
+[[ -n "$CHROMIUM_SRC" && -d "$CHROMIUM_SRC" ]] || { echo "Usage: zoekt-overlay-watch /path/to/chromium/src" >&2; exit 2; }
+
+cmd=(~/.local/bin/zoekt-overlay-refresh "$CHROMIUM_SRC")
+
+if command -v watchexec >/dev/null 2>&1; then
+  exec watchexec -w "$CHROMIUM_SRC" --debounce 300ms --shell=none -- "${cmd[@]}"
+elif command -v fswatch >/dev/null 2>&1; then
+  fswatch -or 0.3 "$CHROMIUM_SRC" | while read -r _; do "${cmd[@]}"; done
+elif command -v inotifywait >/dev/null 2>&1; then
+  inotifywait -mrq -e modify,create,delete,move "$CHROMIUM_SRC" | \
+  awk 'BEGIN{cmd=":"} { if (cmd!="running") { system("'"'"${cmd[*]}"'"'" &"); cmd="running" } }'
+else
+  echo "Install one of: watchexec, fswatch, inotify-tools." >&2
+  exit 1
+fi

--- a/dot_zprofile
+++ b/dot_zprofile
@@ -1,1 +1,5 @@
 export RIPGREP_CONFIG_PATH="$HOME/.ripgreprc"
+
+export CHROMIUM_SRC="$HOME/src/chromium/src"
+export ZOEKT_INDEX_DIR="$HOME/.zoekt/chromium"
+export ZOEKT_OVERLAY_DIR="$HOME/.zoekt/chromium-overlay"

--- a/run_once_70-install-zoekt.ps1.tmpl
+++ b/run_once_70-install-zoekt.ps1.tmpl
@@ -1,0 +1,20 @@
+{{ if eq .chezmoi.os "windows" -}}
+$ErrorActionPreference = 'Stop'
+if (-not (Get-Command go -ErrorAction SilentlyContinue)) {
+  winget install -e --id GoLang.Go -h 0
+}
+
+$env:GOPATH = $env:GOPATH ?? "$env:USERPROFILE\go"
+$GOBIN = $env:GOBIN ?? (Join-Path $env:GOPATH "bin")
+New-Item -ItemType Directory -Force -Path $GOBIN | Out-Null
+if (-not ((Get-Content $PROFILE -ErrorAction SilentlyContinue) -match [regex]::Escape($GOBIN))) {
+  New-Item -ItemType File -Force -Path $PROFILE | Out-Null
+  Add-Content -Path $PROFILE -Value "`n`$env:Path = `"$GOBIN;`$env:Path`"`n"
+}
+
+go install github.com/sourcegraph/zoekt/cmd/...@latest
+
+New-Item -ItemType Directory -Force -Path "$env:USERPROFILE\.zoekt\chromium" | Out-Null
+New-Item -ItemType Directory -Force -Path "$env:USERPROFILE\.zoekt\chromium-overlay" | Out-Null
+Write-Host "[zoekt] Installed and created index dirs."
+{{ end -}}

--- a/run_once_70-install-zoekt.sh.tmpl
+++ b/run_once_70-install-zoekt.sh.tmpl
@@ -1,0 +1,24 @@
+{{ if ne .chezmoi.os "windows" -}}
+#!/usr/bin/env bash
+set -euo pipefail
+
+if command -v brew >/dev/null 2>&1; then
+  brew install go universal-ctags || true
+elif command -v apt-get >/dev/null 2>&1; then
+  sudo apt-get update -y
+  sudo apt-get install -y golang-go universal-ctags || true
+elif command -v dnf >/dev/null 2>&1; then
+  sudo dnf install -y golang ctags || true
+fi
+
+export GOPATH="${GOPATH:-$HOME/go}"
+export GOBIN="${GOBIN:-$GOPATH/bin}"
+mkdir -p "$GOBIN"
+case ":$PATH:" in *":$GOBIN:"*) ;; *) echo 'export PATH="$HOME/go/bin:$PATH"' >> "$HOME/.profile";; esac
+
+go install github.com/sourcegraph/zoekt/cmd/...@latest
+
+mkdir -p "${ZOEKT_INDEX_DIR:-$HOME/.zoekt/chromium}" "${ZOEKT_OVERLAY_DIR:-$HOME/.zoekt/chromium-overlay}"
+
+echo "[zoekt] Installed CLI + created index dirs."
+{{ end -}}


### PR DESCRIPTION
## Summary
- configure Zoekt install scripts for Unix and Windows
- add Chromium indexer and overlay watchers with git hooks and systemd units
- provide rgx search wrappers for shells and Visual Studio

## Testing
- `shellcheck dot_local/bin/executable_zoekt-index-chromium dot_local/bin/executable_zoekt-overlay-refresh dot_local/bin/executable_zoekt-overlay-watch dot_local/bin/executable_install-zoekt-githooks dot_local/bin/executable_rgx dot_config/git/template/hooks/post-commit dot_config/git/template/hooks/post-merge dot_config/git/template/hooks/post-checkout dot_zprofile`
- `sudo apt-get install -y powershell` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68c5884e68e88324bdd6d10106a477fb