### PR TITLE
Fix Zoekt installer for PowerShell 5

### DIFF
--- a/dot_zprofile
+++ b/dot_zprofile
@@ -1,5 +1,6 @@
 export RIPGREP_CONFIG_PATH="$HOME/.ripgreprc"
 
+# Environment variables used by the real-time Zoekt search integration.
 export CHROMIUM_SRC="$HOME/src/chromium/src"
 export ZOEKT_INDEX_DIR="$HOME/.zoekt/chromium"
 export ZOEKT_OVERLAY_DIR="$HOME/.zoekt/chromium-overlay"

--- a/run_once_70-install-zoekt.ps1.tmpl
+++ b/run_once_70-install-zoekt.ps1.tmpl
@@ -4,8 +4,16 @@ if (-not (Get-Command go -ErrorAction SilentlyContinue)) {
   winget install -e --id GoLang.Go -h 0
 }
 
-$env:GOPATH = $env:GOPATH ?? "$env:USERPROFILE\go"
-$GOBIN = $env:GOBIN ?? (Join-Path $env:GOPATH "bin")
+# PowerShell 5.1 does not support the null-coalescing (??) operator.
+# Fall back to explicit checks when setting GOPATH and GOBIN.
+if (-not $env:GOPATH) {
+  $env:GOPATH = Join-Path $env:USERPROFILE 'go'
+}
+if ($env:GOBIN) {
+  $GOBIN = $env:GOBIN
+} else {
+  $GOBIN = Join-Path $env:GOPATH 'bin'
+}
 New-Item -ItemType Directory -Force -Path $GOBIN | Out-Null
 if (-not ((Get-Content $PROFILE -ErrorAction SilentlyContinue) -match [regex]::Escape($GOBIN))) {
   New-Item -ItemType File -Force -Path $PROFILE | Out-Null
@@ -14,7 +22,8 @@ if (-not ((Get-Content $PROFILE -ErrorAction SilentlyContinue) -match [regex]::E
 
 go install github.com/sourcegraph/zoekt/cmd/...@latest
 
-New-Item -ItemType Directory -Force -Path "$env:USERPROFILE\.zoekt\chromium" | Out-Null
-New-Item -ItemType Directory -Force -Path "$env:USERPROFILE\.zoekt\chromium-overlay" | Out-Null
+# Create the Zoekt index and overlay directories under %USERPROFILE%
+New-Item -ItemType Directory -Force -Path (Join-Path $env:USERPROFILE '.zoekt\chromium')        | Out-Null
+New-Item -ItemType Directory -Force -Path (Join-Path $env:USERPROFILE '.zoekt\chromium-overlay') | Out-Null
 Write-Host "[zoekt] Installed and created index dirs."
 {{ end -}}


### PR DESCRIPTION
## Summary
- replace PowerShell 7 null-coalescing with explicit checks in Zoekt installer
- document Zoekt environment variables in `.zprofile`

## Testing
- `chezmoi apply --dry-run -S .` *(fails: .env not defined)*
- `chezmoi doctor -S .`


------
https://chatgpt.com/codex/tasks/task_e_68c59588752c8324a548beb087de75b9