### PR TITLE
CI: sandbox chezmoi and upgrade checkout

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -1,0 +1,12 @@
+# Make templates tolerant of missing keys like `.env.FOO` in CI.
+[template]
+  options = ["missingkey=zero"]
+
+# Use a sandbox target dir in CI so we never touch the runner's real HOME.
+{{- $tmp := coalesce (env "RUNNER_TEMP") (env "TMPDIR") (env "TEMP") (env "TMP") "/tmp" -}}
+destDir = "{{ joinPath $tmp "chezmoi-home" }}"
+
+# Ensure `.env` exists so `.env.*` lookups don't fail outright.
+[data]
+  env = {}
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Ensure chezmoi is installed (Unix)
         if: runner.os != 'Windows'
@@ -21,8 +23,7 @@ jobs:
             echo "chezmoi not found. Attempting to install"
             if command -v apt-get >/dev/null; then
               sudo apt-get update -y
-              sudo apt-get install -y chezmoi || \
-                sh -c "$(curl -fsLS get.chezmoi.io)" -- -b /usr/local/bin
+              sudo apt-get install -y chezmoi || sh -c "$(curl -fsLS get.chezmoi.io)" -- -b /usr/local/bin
             elif command -v brew >/dev/null; then
               brew install chezmoi
             else
@@ -35,16 +36,42 @@ jobs:
         shell: pwsh
         run: |
           if (-not (Get-Command chezmoi -ErrorAction SilentlyContinue)) {
-            Write-Host 'chezmoi not found. Attempting choco install.'
-            choco install chezmoi -y \
-              || throw 'chezmoi is required. Install it manually.'
+            Write-Host 'chezmoi not found. Installing via choco...'
+            choco install chezmoi -y --no-progress
           }
 
-      - name: Dry-run apply
-        continue-on-error: true
+      - name: Initialize chezmoi config (from template) [Unix]
+        if: runner.os != 'Windows'
+        shell: bash
         run: |
-          chezmoi apply --dry-run -S . || true
+          # Generate config from .chezmoi.toml.tmpl in this repo
+          chezmoi init --source .
+          mkdir -p "$RUNNER_TEMP/chezmoi-home"
 
-      - name: Doctor
+      - name: Initialize chezmoi config (from template) [Windows]
+        if: runner.os == 'Windows'
+        shell: pwsh
         run: |
-          chezmoi doctor -S .
+          chezmoi init --source .
+          New-Item -ItemType Directory -Force -Path "$env:RUNNER_TEMP\chezmoi-home" | Out-Null
+
+      - name: Dry-run apply (Unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: chezmoi apply --dry-run -S . --destination "$RUNNER_TEMP/chezmoi-home"
+
+      - name: Dry-run apply (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: chezmoi apply --dry-run -S . --destination "$env:RUNNER_TEMP\chezmoi-home"
+
+      - name: Doctor (Unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: chezmoi doctor -S . --destination "$RUNNER_TEMP/chezmoi-home"
+
+      - name: Doctor (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: chezmoi doctor -S . --destination "$env:RUNNER_TEMP\chezmoi-home"
+


### PR DESCRIPTION
## Summary
- add CI-safe `.chezmoi.toml.tmpl` to tolerate missing `.env.*` keys and set a sandbox destination
- upgrade workflow to `actions/checkout@v4`
- initialize chezmoi from config template and run dry-run/doctor against a temp home

## Testing
- `chezmoi apply --dry-run -S . --destination /tmp/chezmoi-home` *(fails: `sh: 30: eval: [[: not found`)*
- `chezmoi doctor -S . --destination /tmp/chezmoi-home`


------
https://chatgpt.com/codex/tasks/task_e_68c5cccce6f48324bc94e79ad908d27a