### PR TITLE
feat: auto-install Vimium Chrome extension

### DIFF
--- a/Library/Application Support/Google/Chrome/External Extensions/dbepggeogbaibhgnhhndojpepiihcmeb.json
+++ b/Library/Application Support/Google/Chrome/External Extensions/dbepggeogbaibhgnhhndojpepiihcmeb.json
@@ -1,0 +1,3 @@
+{
+  "external_update_url": "https://clients2.google.com/service/update2/crx"
+}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Dotfiles
 
-Personal dotfiles for my development environment, managed with [chezmoi](https://www.chezmoi.io/). Chezmoi bootstraps a vanilla [LazyVim](https://lazyvim.github.io) configuration for Neovim and also sets up tools like Ripgrep, Helix, Kitty, VS Code, and more so they can be reproduced on any machine. JetBrainsMono Nerd Font is installed and configured as the default font for VS Code, Windows Terminal, macOS Terminal, and Kitty.
+Personal dotfiles for my development environment, managed with [chezmoi](https://www.chezmoi.io/). Chezmoi bootstraps a vanilla [LazyVim](https://lazyvim.github.io) configuration for Neovim and also sets up tools like Ripgrep, Helix, Kitty, VS Code, and more so they can be reproduced on any machine. JetBrainsMono Nerd Font is installed and configured as the default font for VS Code, Windows Terminal, macOS Terminal, and Kitty. It also configures Google Chrome to install the [Vimium](https://chromewebstore.google.com/detail/vimium/dbepggeogbaibhgnhhndojpepiihcmeb) extension automatically.
 
 ## Installation with chezmoi
 

--- a/dot_config/google-chrome/External Extensions/dbepggeogbaibhgnhhndojpepiihcmeb.json
+++ b/dot_config/google-chrome/External Extensions/dbepggeogbaibhgnhhndojpepiihcmeb.json
@@ -1,0 +1,3 @@
+{
+  "external_update_url": "https://clients2.google.com/service/update2/crx"
+}


### PR DESCRIPTION
## Summary
- auto-install Vimium Chrome extension on Linux and macOS via policy files
- mention Vimium Chrome extension in README

## Testing
- `./bin/chezmoi doctor`


------
https://chatgpt.com/codex/tasks/task_e_68c771112e288324a8021a04a61eb18c