### PR TITLE
Configure AltTab with Vim keys and Command shortcut

### DIFF
--- a/run_onchange_53-configure-alt-tab.sh.tmpl
+++ b/run_onchange_53-configure-alt-tab.sh.tmpl
@@ -1,0 +1,20 @@
+{{- /* chezmoi template: run on change; safe on repeated runs */ -}}
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "{{ .chezmoi.os }}" != "darwin" ]; then
+  exit 0
+fi
+
+# Ensure macOS "defaults" command is available
+if ! command -v defaults >/dev/null 2>&1; then
+  exit 0
+fi
+
+# Enable Vim-style navigation and use Command as the hold shortcut
+defaults write com.lwouis.alt-tab-macos vimKeysEnabled -bool true
+for key in holdShortcut holdShortcut2 holdShortcut3; do
+  defaults write com.lwouis.alt-tab-macos "$key" -string "⌘"
+done
+
+exit 0


### PR DESCRIPTION
## Summary
- configure AltTab via macOS `defaults` to enable Vim key navigation
- set Command as the primary AltTab hold shortcut

## Testing
- `shellcheck -e SC1009,SC1054,SC1073,SC1083,SC1056,SC1072 run_onchange_53-configure-alt-tab.sh.tmpl`


------
https://chatgpt.com/codex/tasks/task_e_68c771e61bf08324abcf0eef736b9ddb