### PR TITLE
Handle root installs without sudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ chezmoi apply
 ### Linux
 
 ```bash
-sh -c "$curl -fsLS get.chezmoi.io/lb)" -- init --apply $F286
-sudo ~/.local/bin/chezmoi apply
+sh -c "$(curl -fsLS get.chezmoi.io/lb)" -- init --apply $F286
+~/.local/bin/chezmoi apply
 
 
 sudo apt-get update -qq && sudo apt-get install -y git chezmoi


### PR DESCRIPTION
## Summary
- avoid unconditionally calling sudo in run_once_20-install-dev-tools.sh so package managers work when running as root
- try to install git before cloning LazyVim so the bootstrap runs in container environments
- clarify the Linux README instructions to run chezmoi apply without sudo

## Testing
- bash -n run_once_20-install-dev-tools.sh

------
https://chatgpt.com/codex/tasks/task_e_68d2d68af3388324ad75a99d98751672