### PR TITLE
Update VS Code scroll and tab keybindings

### DIFF
--- a/common/.config/Code/User/keybindings.json
+++ b/common/.config/Code/User/keybindings.json
@@ -34,6 +34,48 @@
   { "key": "cmd+enter",  "command": "renameFile",          "when": "explorerViewletVisible && filesExplorerFocus && !inputFocus" },
   { "key": "ctrl+enter", "command": "explorer.openToSide", "when": "explorerViewletVisible && filesExplorerFocus && !inputFocus" },
   
+  // Scroll up 16 Lines
+  {
+    "key": "cmd+u",
+    "command": "runCommands",
+    "when": "textInputFocus && vim.mode == 'Normal'",
+    "args": {
+      "commands": [
+        "scrollLineUp",
+        "cursorUp",
+        "scrollLineUp",
+        "cursorUp",
+        "scrollLineUp",
+        "cursorUp",
+        "scrollLineUp",
+        "cursorUp",
+        "scrollLineUp",
+        "cursorUp",
+        "scrollLineUp",
+        "cursorUp",
+        "scrollLineUp",
+        "cursorUp",
+        "scrollLineUp",
+        "cursorUp",
+        "scrollLineUp",
+        "cursorUp",
+        "scrollLineUp",
+        "cursorUp",
+        "scrollLineUp",
+        "cursorUp",
+        "scrollLineUp",
+        "cursorUp",
+        "scrollLineUp",
+        "cursorUp",
+        "scrollLineUp",
+        "cursorUp",
+        "scrollLineUp",
+        "cursorUp",
+        "scrollLineUp",
+        "cursorUp"
+      ]
+    }
+  },
   // Scroll up 16 Lines (Shift+K alias for Cmd+U)
   {
     "key": "shift+k",
@@ -73,6 +115,48 @@
         "cursorUp",
         "scrollLineUp",
         "cursorUp"
+      ]
+    }
+  },
+  // Scroll down 16 Lines
+  {
+    "key": "cmd+d",
+    "command": "runCommands",
+    "when": "textInputFocus && vim.mode == 'Normal'",
+    "args": {
+      "commands": [
+        "scrollLineDown",
+        "cursorDown",
+        "scrollLineDown",
+        "cursorDown",
+        "scrollLineDown",
+        "cursorDown",
+        "scrollLineDown",
+        "cursorDown",
+        "scrollLineDown",
+        "cursorDown",
+        "scrollLineDown",
+        "cursorDown",
+        "scrollLineDown",
+        "cursorDown",
+        "scrollLineDown",
+        "cursorDown",
+        "scrollLineDown",
+        "cursorDown",
+        "scrollLineDown",
+        "cursorDown",
+        "scrollLineDown",
+        "cursorDown",
+        "scrollLineDown",
+        "cursorDown",
+        "scrollLineDown",
+        "cursorDown",
+        "scrollLineDown",
+        "cursorDown",
+        "scrollLineDown",
+        "cursorDown",
+        "scrollLineDown",
+        "cursorDown"
       ]
     }
   },

--- a/common/.config/Code/User/settings.json
+++ b/common/.config/Code/User/settings.json
@@ -921,8 +921,16 @@
       "commands": ["workbench.action.nextEditor"]
     },
     {
+      "before": ["<S-l>"],
+      "commands": ["workbench.action.nextEditor"]
+    },
+    {
       // Previous tab
       "before": ["[", "b"],
+      "commands": ["workbench.action.previousEditor"]
+    },
+    {
+      "before": ["<S-h>"],
       "commands": ["workbench.action.previousEditor"]
     },
     {


### PR DESCRIPTION
## Summary
- add Cmd+U/Cmd+D normal mode scrolling shortcuts in the VS Code keybindings
- map Shift+L/Shift+H to cycle editor tabs in the VS Code Vim settings

## Testing
- ./apply.sh --no *(fails: stow not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d749a1bc808324b2297d4cc083c700