### PR TITLE
feat: map jumplist keys in vscode

### DIFF
--- a/common/.config/Code/User/keybindings.json
+++ b/common/.config/Code/User/keybindings.json
@@ -13,6 +13,18 @@
   { "key": "cmd+left",  "command": "cursorWordStartLeft", "when": "editorTextFocus" },
   { "key": "cmd+right", "command": "cursorWordEndRight",  "when": "editorTextFocus" },
 
+  // ----- LazyVim-style jumplist navigation -----
+  // Remove defaults that conflict with these bindings.
+  { "key": "cmd+o", "command": "-workbench.action.files.openFile" },
+  { "key": "cmd+i", "command": "-editor.action.triggerSuggest" },
+  { "key": "ctrl+i", "command": "-editor.action.triggerSuggest", "when": "editorHasCompletionItemProvider && editorTextFocus && !editorReadonly" },
+
+  // Navigate backward/forward through editor history.
+  { "key": "cmd+o", "command": "workbench.action.navigateBack" },
+  { "key": "cmd+i", "command": "workbench.action.navigateForward" },
+  { "key": "ctrl+o", "command": "workbench.action.navigateBack" },
+  { "key": "ctrl+i", "command": "workbench.action.navigateForward" },
+
   // ----- Word deletion on ⌘ + Backspace / Delete -----
   // Remove defaults (delete to line start/end):
   { "key": "cmd+backspace", "command": "-deleteAllLeft",  "when": "editorTextFocus && !editorReadonly" },


### PR DESCRIPTION
## Summary
- add LazyVim-style jumplist navigation bindings for VS Code using Cmd/Ctrl+O and Cmd/Ctrl+I
- disable the conflicting default bindings so the new shortcuts take effect reliably

## Testing
- ./apply.sh --no *(fails: stow: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d749edde048324b81e862f5b85699e